### PR TITLE
Update 0001-ntdll-Ensure-process-dlls-are-not-attached-too-early.patch

### DIFF
--- a/patches/ntdll-Attach_Process_DLLs/0001-ntdll-Ensure-process-dlls-are-not-attached-too-early.patch
+++ b/patches/ntdll-Attach_Process_DLLs/0001-ntdll-Ensure-process-dlls-are-not-attached-too-early.patch
@@ -11,19 +11,18 @@ diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
 index 518a99f590..94668e8ba4 100644
 --- a/dlls/ntdll/loader.c
 +++ b/dlls/ntdll/loader.c
-@@ -64,6 +64,7 @@ WINE_DECLARE_DEBUG_CHANNEL(pid);
- typedef DWORD (CALLBACK *DLLENTRYPROC)(HMODULE,DWORD,LPVOID);
+@@ -64,6 +64,7 @@ typedef DWORD (CALLBACK *DLLENTRYPROC)(H
  typedef void  (CALLBACK *LDRENUMPROC)(LDR_MODULE *, void *, BOOLEAN *);
  
+ static BOOL imports_fixup_done = FALSE;  /* set once the imports have been fixed up, before attaching them */
 +static BOOL process_attaching = TRUE;   /* set on process attach to avoid calling callbacks too early */
  static BOOL process_detaching = FALSE;  /* set on process detach to avoid deadlocks with thread detach */
  static int free_lib_count;   /* recursion depth of LdrUnloadDll calls */
  
-@@ -452,7 +453,20 @@ static FARPROC find_forwarded_export( HMODULE module, const char *forward, LPCWS
-         if (load_dll( load_path, mod_name, 0, &wm ) == STATUS_SUCCESS &&
-             !(wm->ldr.Flags & LDR_DONT_RESOLVE_REFS))
-         {
--            if (process_attach( wm, NULL ) != STATUS_SUCCESS)
+@@ -459,6 +460,19 @@ static FARPROC find_forwarded_export( HM
+                     current_modref->deps = deps;
+                 }
+             }
 +            if (process_attaching)
 +            {
 +                WINE_MODREF **deps, *prev = get_modref( module );
@@ -37,18 +36,17 @@ index 518a99f590..94668e8ba4 100644
 +                    prev->deps[prev->nDeps++] = wm;
 +                }
 +            }
-+            else if (process_attach( wm, NULL ) != STATUS_SUCCESS)
+             else if (process_attach( wm, NULL ) != STATUS_SUCCESS)
              {
                  LdrUnloadDll( wm->ldr.BaseAddress );
-                 wm = NULL;
-@@ -3005,6 +3019,7 @@ static NTSTATUS attach_process_dlls( void *wm )
- {
-     NTSTATUS status;
+@@ -2995,6 +3009,7 @@ NTSTATUS attach_dlls( CONTEXT *context )
+     WINE_MODREF *wm;
+     LPCWSTR load_path = NtCurrentTeb()->Peb->ProcessParameters->DllPath.Buffer;
  
 +    process_attaching = FALSE;
      pthread_sigmask( SIG_UNBLOCK, &server_block_set, NULL );
  
-     RtlEnterCriticalSection( &loader_section );
+     if (process_detaching) return STATUS_SUCCESS;
 -- 
 2.12.2
 


### PR DESCRIPTION
Don't know if this works but it appears to allow the patch to be applied.