### PR TITLE
Update 0001-ntdll-Add-support-for-hiding-wine-version-informatio.patch

### DIFF
--- a/patches/ntdll-Hide_Wine_Exports/0001-ntdll-Add-support-for-hiding-wine-version-informatio.patch
+++ b/patches/ntdll-Hide_Wine_Exports/0001-ntdll-Add-support-for-hiding-wine-version-informatio.patch
@@ -13,12 +13,13 @@ diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
 index 94668e8ba4..f4e002a060 100644
 --- a/dlls/ntdll/loader.c
 +++ b/dlls/ntdll/loader.c
-@@ -64,9 +64,12 @@ WINE_DECLARE_DEBUG_CHANNEL(pid);
+@@ -63,10 +63,13 @@ WINE_DECLARE_DEBUG_CHANNEL(imports);
  typedef DWORD (CALLBACK *DLLENTRYPROC)(HMODULE,DWORD,LPVOID);
  typedef void  (CALLBACK *LDRENUMPROC)(LDR_MODULE *, void *, BOOLEAN *);
  
 +#define IS_OPTION_TRUE(ch) ((ch) == 'y' || (ch) == 'Y' || (ch) == 't' || (ch) == 'T' || (ch) == '1')
 +
+ static BOOL imports_fixup_done = FALSE;  /* set once the imports have been fixed up, before attaching them */
  static BOOL process_attaching = TRUE;   /* set on process attach to avoid calling callbacks too early */
  static BOOL process_detaching = FALSE;  /* set on process detach to avoid deadlocks with thread detach */
  static int free_lib_count;   /* recursion depth of LdrUnloadDll calls */
@@ -26,7 +27,7 @@ index 94668e8ba4..f4e002a060 100644
  
  static const char * const reason_names[] =
  {
-@@ -1485,6 +1488,96 @@ NTSTATUS WINAPI LdrUnlockLoaderLock( ULONG flags, ULONG_PTR magic )
+@@ -1449,6 +1452,96 @@ NTSTATUS WINAPI LdrUnlockLoaderLock( ULO
  }
  
  
@@ -123,7 +124,7 @@ index 94668e8ba4..f4e002a060 100644
  /******************************************************************
   *		LdrGetProcedureAddress  (NTDLL.@)
   */
-@@ -1505,7 +1598,7 @@ NTSTATUS WINAPI LdrGetProcedureAddress(HMODULE module, const ANSI_STRING *name,
+@@ -1469,7 +1562,7 @@ NTSTATUS WINAPI LdrGetProcedureAddress(H
          LPCWSTR load_path = NtCurrentTeb()->Peb->ProcessParameters->DllPath.Buffer;
          void *proc = name ? find_named_export( module, exports, exp_size, name->Buffer, -1, load_path )
                            : find_ordinal_export( module, exports, exp_size, ord - exports->Base, load_path );
@@ -132,14 +133,6 @@ index 94668e8ba4..f4e002a060 100644
          {
              *address = proc;
              ret = STATUS_SUCCESS;
-@@ -3128,6 +3221,7 @@ void WINAPI LdrInitializeThunk( void *kernel_start, ULONG_PTR unknown2,
-     if (!peb->ProcessParameters->WindowTitle.Buffer)
-         peb->ProcessParameters->WindowTitle = wm->ldr.FullDllName;
-     version_init( wm->ldr.FullDllName.Buffer );
-+    hidden_exports_init( wm->ldr.FullDllName.Buffer );
-     virtual_set_large_address_space();
- 
-     LdrQueryImageFileExecutionOptions( &peb->ProcessParameters->ImagePathName, globalflagW,
 diff --git a/dlls/ntdll/ntdll_misc.h b/dlls/ntdll/ntdll_misc.h
 index 6549a71fc0..6e51612380 100644
 --- a/dlls/ntdll/ntdll_misc.h
@@ -158,4 +151,3 @@ index 6549a71fc0..6e51612380 100644
                                LARGE_INTEGER *kernel, LARGE_INTEGER *user) DECLSPEC_HIDDEN;
 -- 
 2.12.2
-


### PR DESCRIPTION
allows the patch to be applied