### PR TITLE
Update 0001-ntdll-Do-not-allow-to-allocate-thread-stack-for-curr.patch

### DIFF
--- a/patches/ntdll-Dealloc_Thread_Stack/0001-ntdll-Do-not-allow-to-allocate-thread-stack-for-curr.patch
+++ b/patches/ntdll-Dealloc_Thread_Stack/0001-ntdll-Do-not-allow-to-allocate-thread-stack-for-curr.patch
@@ -21,23 +21,6 @@ index ba296d25c3c..faa258a27f4 100644
  };
  
  C_ASSERT( sizeof(struct ntdll_thread_data) <= sizeof(((TEB *)0)->GdiTebBatch) );
-diff --git a/dlls/ntdll/thread.c b/dlls/ntdll/thread.c
-index ba1be0f3d8a..e8f07efb829 100644
---- a/dlls/ntdll/thread.c
-+++ b/dlls/ntdll/thread.c
-@@ -445,6 +445,12 @@ void exit_thread( int status )
-         if (thread_data->pthread_id)
-         {
-             pthread_join( thread_data->pthread_id, NULL );
-+            if ((ULONG_PTR)thread_data->pthread_stack & 1)
-+            {
-+                void *addr = (void *)((ULONG_PTR)thread_data->pthread_stack & ~1);
-+                SIZE_T size = 0;
-+                NtFreeVirtualMemory( GetCurrentProcess(), &addr, &size, MEM_RELEASE );
-+            }
-             signal_free_thread( teb );
-         }
-     }
 diff --git a/dlls/ntdll/virtual.c b/dlls/ntdll/virtual.c
 index 4aeb282adf7..68c0148fbb5 100644
 --- a/dlls/ntdll/virtual.c
@@ -70,4 +53,3 @@ index 4aeb282adf7..68c0148fbb5 100644
              delete_view( view );
 -- 
 2.13.1
-


### PR DESCRIPTION
Allows the patch to be applied