### PR TITLE
Update 0001-ntdll-Catch-windows-int-0x2e-syscall-on-i386.patch

### DIFF
--- a/patches/ntdll-Interrupt-0x2e/0001-ntdll-Catch-windows-int-0x2e-syscall-on-i386.patch
+++ b/patches/ntdll-Interrupt-0x2e/0001-ntdll-Catch-windows-int-0x2e-syscall-on-i386.patch
@@ -43,14 +43,13 @@ diff --git a/include/wine/exception.h b/include/wine/exception.h
 index f275568f4d..b8aeb3b866 100644
 --- a/include/wine/exception.h
 +++ b/include/wine/exception.h
-@@ -259,6 +259,7 @@ static inline EXCEPTION_REGISTRATION_RECORD *__wine_get_frame(void)
+@@ -302,6 +302,7 @@ static inline EXCEPTION_REGISTRATION_REC
  
  #define EXCEPTION_WINE_STUB       0x80000100  /* stub entry point called */
  #define EXCEPTION_WINE_ASSERTION  0x80000101  /* assertion failed */
 +#define EXCEPTION_WINE_SYSCALL    0x80000103
  
- /* unhandled return status from vm86 mode */
- #define EXCEPTION_VM86_INTx       0x80000110
+ #ifdef __cplusplus
+ }
 -- 
 2.11.0
-


### PR DESCRIPTION
Allows the patch file to be applied