### PR TITLE
Update 0004-winex11.drv-Indicate-direct-rendering-through-OpenGL.patch

### DIFF
--- a/patches/Pipelight/0004-winex11.drv-Indicate-direct-rendering-through-OpenGL.patch
+++ b/patches/Pipelight/0004-winex11.drv-Indicate-direct-rendering-through-OpenGL.patch
@@ -11,38 +11,14 @@ diff --git a/dlls/winex11.drv/opengl.c b/dlls/winex11.drv/opengl.c
 index 71af3db..966d32d 100644
 --- a/dlls/winex11.drv/opengl.c
 +++ b/dlls/winex11.drv/opengl.c
-@@ -440,6 +440,7 @@ static int GLXErrorHandler(Display *dpy, XErrorEvent *event, void *arg)
+@@ -439,7 +439,7 @@ static int GLXErrorHandler(Display *dpy,
+ 
  static BOOL X11DRV_WineGL_InitOpenglInfo(void)
  {
-     static const char legacy_extensions[] = " WGL_EXT_extensions_string WGL_EXT_swap_control";
+-    static const char legacy_extensions[] = " WGL_EXT_extensions_string WGL_EXT_swap_control";
 +    static const char direct_extension[] = " WINE_EXT_direct_rendering";
  
      int screen = DefaultScreen(gdi_display);
      Window win = 0, root = 0;
-@@ -491,10 +492,13 @@ static BOOL X11DRV_WineGL_InitOpenglInfo(void)
-     }
-     gl_renderer = (const char *)opengl_funcs.gl.p_glGetString(GL_RENDERER);
-     WineGLInfo.glVersion = (const char *) opengl_funcs.gl.p_glGetString(GL_VERSION);
-+    WineGLInfo.glxDirect = pglXIsDirect(gdi_display, ctx);
-     str = (const char *) opengl_funcs.gl.p_glGetString(GL_EXTENSIONS);
--    WineGLInfo.glExtensions = HeapAlloc(GetProcessHeap(), 0, strlen(str)+sizeof(legacy_extensions));
-+    WineGLInfo.glExtensions = HeapAlloc(GetProcessHeap(), 0, strlen(str)+sizeof(legacy_extensions)+sizeof(direct_extension));
-     strcpy(WineGLInfo.glExtensions, str);
-     strcat(WineGLInfo.glExtensions, legacy_extensions);
-+    if (WineGLInfo.glxDirect)
-+        strcat(WineGLInfo.glExtensions, direct_extension);
- 
-     /* Get the common GLX version supported by GLX client and server ( major/minor) */
-     pglXQueryVersion(gdi_display, &WineGLInfo.glxVersion[0], &WineGLInfo.glxVersion[1]);
-@@ -508,7 +512,7 @@ static BOOL X11DRV_WineGL_InitOpenglInfo(void)
-     WineGLInfo.glxClientExtensions = pglXGetClientString(gdi_display, GLX_EXTENSIONS);
- 
-     WineGLInfo.glxExtensions = pglXQueryExtensionsString(gdi_display, screen);
--    WineGLInfo.glxDirect = pglXIsDirect(gdi_display, ctx);
-+
- 
-     TRACE("GL version             : %s.\n", WineGLInfo.glVersion);
-     TRACE("GL renderer            : %s.\n", gl_renderer);
 -- 
 1.7.9.5
-


### PR DESCRIPTION
Allows the patch to be applied. I don't know if this works but it I think that most of the original patch or something similar was put into Wine 3.2