### PR TITLE
Update 0001-windowscodecs-tests-Add-a-test-for-8bpp-indexed-TIFF.patch

### DIFF
--- a/patches/windowscodecs-TIFF_Support/0001-windowscodecs-tests-Add-a-test-for-8bpp-indexed-TIFF.patch
+++ b/patches/windowscodecs-TIFF_Support/0001-windowscodecs-tests-Add-a-test-for-8bpp-indexed-TIFF.patch
@@ -11,11 +11,10 @@ diff --git a/dlls/windowscodecs/tests/tiffformat.c b/dlls/windowscodecs/tests/ti
 index e4a4b66..3291b48 100644
 --- a/dlls/windowscodecs/tests/tiffformat.c
 +++ b/dlls/windowscodecs/tests/tiffformat.c
-@@ -134,6 +134,49 @@ static const struct tiff_8bpp_alpha
-     { 96, 1 },
+@@ -136,6 +136,49 @@ static const struct tiff_8bpp_alpha
      { 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88 }
  };
-+
+ 
 +static const struct tiff_8bpp_data
 +{
 +    USHORT byte_order;
@@ -58,10 +57,11 @@ index e4a4b66..3291b48 100644
 +    { { 0 } },
 +    { 0,1,2,3 }
 +};
- #include "poppack.h"
- 
- static IWICImagingFactory *factory;
-@@ -159,29 +202,41 @@ static IStream *create_stream(const void *data, int data_size)
++
+ static const struct tiff_resolution_test_data
+ {
+     struct IFD_rational resx;
+@@ -235,29 +278,41 @@ static IStream *create_stream(const void
      return stream;
  }
  
@@ -116,7 +116,7 @@ index e4a4b66..3291b48 100644
  {
      HRESULT hr;
      IWICBitmapDecoder *decoder;
-@@ -189,9 +244,9 @@ static void test_tiff_palette(void)
+@@ -265,9 +320,9 @@ static void test_tiff_palette(void)
      IWICPalette *palette;
      GUID format;
  
@@ -129,7 +129,7 @@ index e4a4b66..3291b48 100644
  
      hr = IWICBitmapDecoder_GetFrame(decoder, 0, &frame);
      ok(hr == S_OK, "GetFrame error %#x\n", hr);
-@@ -323,9 +378,9 @@ static void test_tiff_8bpp_alpha(void)
+@@ -399,9 +454,9 @@ static void test_tiff_8bpp_alpha(void)
      static const BYTE expected_data[16] = { 0x11,0x11,0x11,0x22,0x33,0x33,0x33,0x44,
                                              0x55,0x55,0x55,0x66,0x77,0x77,0x77,0x88 };
  
@@ -142,7 +142,7 @@ index e4a4b66..3291b48 100644
  
      hr = IWICBitmapDecoder_GetFrameCount(decoder, &frame_count);
      ok(hr == S_OK, "GetFrameCount error %#x\n", hr);
-@@ -370,6 +425,84 @@ static void test_tiff_8bpp_alpha(void)
+@@ -446,6 +501,84 @@ static void test_tiff_8bpp_alpha(void)
      IWICBitmapDecoder_Release(decoder);
  }
  
@@ -224,10 +224,10 @@ index e4a4b66..3291b48 100644
 +    IWICBitmapDecoder_Release(decoder);
 +}
 +
- START_TEST(tiffformat)
+ static void test_tiff_resolution(void)
  {
      HRESULT hr;
-@@ -381,7 +514,8 @@ START_TEST(tiffformat)
+@@ -509,7 +642,8 @@ START_TEST(tiffformat)
      ok(hr == S_OK, "CoCreateInstance error %#x\n", hr);
      if (FAILED(hr)) return;
  
@@ -236,7 +236,6 @@ index e4a4b66..3291b48 100644
 +    test_tiff_8bpp_palette();
      test_QueryCapability();
      test_tiff_8bpp_alpha();
- 
+     test_tiff_resolution();
 -- 
 2.9.0
-


### PR DESCRIPTION
allows the patch file to be applied