### PR TITLE
Update 0004-winex11.drv-Indicate-direct-rendering-through-OpenGL.patch

### DIFF
--- a/patches/Pipelight/0004-winex11.drv-Indicate-direct-rendering-through-OpenGL.patch
+++ b/patches/Pipelight/0004-winex11.drv-Indicate-direct-rendering-through-OpenGL.patch
@@ -11,7 +11,7 @@ diff --git a/dlls/winex11.drv/opengl.c b/dlls/winex11.drv/opengl.c
 index 71af3db..966d32d 100644
 --- a/dlls/winex11.drv/opengl.c
 +++ b/dlls/winex11.drv/opengl.c
-@@ -440,6 +440,7 @@ static int GLXErrorHandler(Display *dpy, XErrorEvent *event, void *arg)
+@@ -440,6 +440,7 @@ static int GLXErrorHandler(Display *dpy,
  static BOOL X11DRV_WineGL_InitOpenglInfo(void)
  {
      static const char legacy_extensions[] = " WGL_EXT_extensions_string WGL_EXT_swap_control";
@@ -19,30 +19,26 @@ index 71af3db..966d32d 100644
  
      int screen = DefaultScreen(gdi_display);
      Window win = 0, root = 0;
-@@ -491,10 +492,13 @@ static BOOL X11DRV_WineGL_InitOpenglInfo(void)
+@@ -493,16 +494,18 @@ static BOOL X11DRV_WineGL_InitOpenglInfo
      }
      gl_renderer = (const char *)opengl_funcs.gl.p_glGetString(GL_RENDERER);
-     WineGLInfo.glVersion = (const char *) opengl_funcs.gl.p_glGetString(GL_VERSION);
-+    WineGLInfo.glxDirect = pglXIsDirect(gdi_display, ctx);
+     gl_version  = (const char *)opengl_funcs.gl.p_glGetString(GL_VERSION);
++    glx_direct = pglXIsDirect(gdi_display, ctx);
      str = (const char *) opengl_funcs.gl.p_glGetString(GL_EXTENSIONS);
--    WineGLInfo.glExtensions = HeapAlloc(GetProcessHeap(), 0, strlen(str)+sizeof(legacy_extensions));
-+    WineGLInfo.glExtensions = HeapAlloc(GetProcessHeap(), 0, strlen(str)+sizeof(legacy_extensions)+sizeof(direct_extension));
-     strcpy(WineGLInfo.glExtensions, str);
-     strcat(WineGLInfo.glExtensions, legacy_extensions);
-+    if (WineGLInfo.glxDirect)
-+        strcat(WineGLInfo.glExtensions, direct_extension);
+-    glExtensions = HeapAlloc(GetProcessHeap(), 0, strlen(str)+sizeof(legacy_extensions));
++    glExtensions = HeapAlloc(GetProcessHeap(), 0, strlen(str)+sizeof(legacy_extensions)+sizeof(direct_extension));
+     strcpy(glExtensions, str);
+     strcat(glExtensions, legacy_extensions);
++    if (glx_direct)
++        strcat(glExtensions, direct_extension);
  
      /* Get the common GLX version supported by GLX client and server ( major/minor) */
-     pglXQueryVersion(gdi_display, &WineGLInfo.glxVersion[0], &WineGLInfo.glxVersion[1]);
-@@ -508,7 +512,7 @@ static BOOL X11DRV_WineGL_InitOpenglInfo(void)
-     WineGLInfo.glxClientExtensions = pglXGetClientString(gdi_display, GLX_EXTENSIONS);
+     pglXQueryVersion(gdi_display, &glxVersion[0], &glxVersion[1]);
  
-     WineGLInfo.glxExtensions = pglXQueryExtensionsString(gdi_display, screen);
--    WineGLInfo.glxDirect = pglXIsDirect(gdi_display, ctx);
-+
+     glxExtensions = pglXQueryExtensionsString(gdi_display, screen);
+-    glx_direct = pglXIsDirect(gdi_display, ctx);
  
-     TRACE("GL version             : %s.\n", WineGLInfo.glVersion);
+     TRACE("GL version             : %s.\n", gl_version);
      TRACE("GL renderer            : %s.\n", gl_renderer);
 -- 
 1.7.9.5
-


### PR DESCRIPTION
Allows the patch to be applied