### PR TITLE
Update 0001-kernel32-tests-Add-basic-tests-for-fake-dlls.patch

### DIFF
--- a/patches/winebuild-Fake_Dlls/0001-kernel32-tests-Add-basic-tests-for-fake-dlls.patch
+++ b/patches/winebuild-Fake_Dlls/0001-kernel32-tests-Add-basic-tests-for-fake-dlls.patch
@@ -11,8 +11,8 @@ diff --git a/dlls/kernel32/tests/loader.c b/dlls/kernel32/tests/loader.c
 index 2587a973031..44c632bdbcf 100644
 --- a/dlls/kernel32/tests/loader.c
 +++ b/dlls/kernel32/tests/loader.c
-@@ -831,6 +831,96 @@ static void test_Loader(void)
-     nt_header.FileHeader.Machine = orig_machine;  /* restore it for the next tests */
+@@ -1289,6 +1289,96 @@ static void test_Loader(void)
+     section.Characteristics = IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ;
  }
  
 +static void test_FakeDLL(void)
@@ -108,7 +108,7 @@ index 2587a973031..44c632bdbcf 100644
  /* Verify linking style of import descriptors */
  static void test_ImportDescriptors(void)
  {
-@@ -3065,6 +3155,7 @@ START_TEST(loader)
+@@ -3598,6 +3688,7 @@ START_TEST(loader)
      }
  
      test_Loader();
@@ -118,4 +118,3 @@ index 2587a973031..44c632bdbcf 100644
      test_section_access();
 -- 
 2.12.2
-


### PR DESCRIPTION
Allows the patch to be applied