### PR TITLE
Update 0002-krnl386.exe16-Do-not-abuse-WOW32Reserved-field-for-1.patch

### DIFF
--- a/patches/winebuild-Fake_Dlls/0002-krnl386.exe16-Do-not-abuse-WOW32Reserved-field-for-1.patch
+++ b/patches/winebuild-Fake_Dlls/0002-krnl386.exe16-Do-not-abuse-WOW32Reserved-field-for-1.patch
@@ -416,56 +416,37 @@ diff --git a/dlls/krnl386.exe16/wowthunk.c b/dlls/krnl386.exe16/wowthunk.c
 index fa49a246ab8..bd69b844607 100644
 --- a/dlls/krnl386.exe16/wowthunk.c
 +++ b/dlls/krnl386.exe16/wowthunk.c
-@@ -222,7 +222,7 @@ static DWORD call16_handler( EXCEPTION_RECORD *record, EXCEPTION_REGISTRATION_RE
-     {
-         /* unwinding: restore the stack pointer in the TEB, and leave the Win16 mutex */
-         STACK32FRAME *frame32 = CONTAINING_RECORD(frame, STACK32FRAME, frame);
--        NtCurrentTeb()->WOW32Reserved = (void *)frame32->frame16;
-+        NtCurrentTeb()->SystemReserved1[0] = (void *)frame32->frame16;
-         _LeaveWin16Lock();
-     }
-     else if (record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION ||
-@@ -543,7 +543,7 @@ BOOL WINAPI K32WOWCallback16Ex( DWORD vpfn16, DWORD dwFlags,
-                     context->SegCs, LOWORD(context->Eip), context->SegDs );
-             while (count) DPRINTF( ",%04x", wstack[--count] );
-             DPRINTF(") ss:sp=%04x:%04x",
--                    SELECTOROF(NtCurrentTeb()->WOW32Reserved), OFFSETOF(NtCurrentTeb()->WOW32Reserved) );
-+                    SELECTOROF(NtCurrentTeb()->SystemReserved1[0]), OFFSETOF(NtCurrentTeb()->SystemReserved1[0]) );
-             DPRINTF(" ax=%04x bx=%04x cx=%04x dx=%04x si=%04x di=%04x bp=%04x es=%04x fs=%04x\n",
-                     (WORD)context->Eax, (WORD)context->Ebx, (WORD)context->Ecx,
-                     (WORD)context->Edx, (WORD)context->Esi, (WORD)context->Edi,
-@@ -608,8 +608,8 @@ BOOL WINAPI K32WOWCallback16Ex( DWORD vpfn16, DWORD dwFlags,
+@@ -453,8 +453,8 @@ BOOL WINAPI K32WOWCallback16Ex( DWORD vp
          if (TRACE_ON(relay))
          {
-             DPRINTF("%04x:RetFrom16() ss:sp=%04x:%04x ",
--                    GetCurrentThreadId(), SELECTOROF(NtCurrentTeb()->WOW32Reserved),
--                    OFFSETOF(NtCurrentTeb()->WOW32Reserved));
-+                    GetCurrentThreadId(), SELECTOROF(NtCurrentTeb()->SystemReserved1[0]),
-+                    OFFSETOF(NtCurrentTeb()->SystemReserved1[0]));
-             DPRINTF(" ax=%04x bx=%04x cx=%04x dx=%04x bp=%04x sp=%04x\n",
-                     (WORD)context->Eax, (WORD)context->Ebx, (WORD)context->Ecx,
-                     (WORD)context->Edx, (WORD)context->Ebp, (WORD)context->Esp );
-@@ -627,10 +627,10 @@ BOOL WINAPI K32WOWCallback16Ex( DWORD vpfn16, DWORD dwFlags,
+             TRACE_(relay)( "\1RetFrom16() ss:sp=%04x:%04x ax=%04x bx=%04x cx=%04x dx=%04x bp=%04x sp=%04x\n",
+-                           SELECTOROF(NtCurrentTeb()->WOW32Reserved),
+-                           OFFSETOF(NtCurrentTeb()->WOW32Reserved),
++                           SELECTOROF(NtCurrentTeb()->SystemReserved1[0]),
++                           OFFSETOF(NtCurrentTeb()->SystemReserved1[0]),
+                            (WORD)context->Eax, (WORD)context->Ebx, (WORD)context->Ecx,
+                            (WORD)context->Edx, (WORD)context->Ebp, (WORD)context->Esp );
+             SYSLEVEL_CheckNotLevel( 2 );
+@@ -470,9 +470,9 @@ BOOL WINAPI K32WOWCallback16Ex( DWORD vp
+             WORD * wstack = (WORD *)stack;
  
-             DPRINTF("%04x:CallTo16(func=%04x:%04x,ds=%04x",
-                     GetCurrentThreadId(), HIWORD(vpfn16), LOWORD(vpfn16),
--                    SELECTOROF(NtCurrentTeb()->WOW32Reserved) );
-+                    SELECTOROF(NtCurrentTeb()->SystemReserved1[0]) );
-             while (count) DPRINTF( ",%04x", wstack[--count] );
-             DPRINTF(") ss:sp=%04x:%04x\n",
--                    SELECTOROF(NtCurrentTeb()->WOW32Reserved), OFFSETOF(NtCurrentTeb()->WOW32Reserved) );
-+                    SELECTOROF(NtCurrentTeb()->SystemReserved1[0]), OFFSETOF(NtCurrentTeb()->SystemReserved1[0]) );
+             TRACE_(relay)( "\1CallTo16(func=%04x:%04x,ds=%04x",
+-                           HIWORD(vpfn16), LOWORD(vpfn16), SELECTOROF(NtCurrentTeb()->WOW32Reserved) );
++                           HIWORD(vpfn16), LOWORD(vpfn16), SELECTOROF(NtCurrentTeb()->SystemReserved1[0]) );
+             while (count) TRACE_(relay)( ",%04x", wstack[--count] );
+-            TRACE_(relay)( ") ss:sp=%04x:%04x\n", SELECTOROF(NtCurrentTeb()->WOW32Reserved),
++            TRACE_(relay)( ") ss:sp=%04x:%04x\n", SELECTOROF(NtCurrentTeb()->SystemReserved1[0]),
+                            OFFSETOF(NtCurrentTeb()->WOW32Reserved) );
              SYSLEVEL_CheckNotLevel( 2 );
          }
- 
-@@ -653,8 +653,8 @@ BOOL WINAPI K32WOWCallback16Ex( DWORD vpfn16, DWORD dwFlags,
+@@ -496,8 +496,8 @@ BOOL WINAPI K32WOWCallback16Ex( DWORD vp
          if (TRACE_ON(relay))
          {
-             DPRINTF("%04x:RetFrom16() ss:sp=%04x:%04x retval=%08x\n",
--                    GetCurrentThreadId(), SELECTOROF(NtCurrentTeb()->WOW32Reserved),
--                    OFFSETOF(NtCurrentTeb()->WOW32Reserved), ret);
-+                    GetCurrentThreadId(), SELECTOROF(NtCurrentTeb()->SystemReserved1[0]),
-+                    OFFSETOF(NtCurrentTeb()->SystemReserved1[0]), ret);
+             TRACE_(relay)( "\1RetFrom16() ss:sp=%04x:%04x retval=%08x\n",
+-                           SELECTOROF(NtCurrentTeb()->WOW32Reserved),
+-                           OFFSETOF(NtCurrentTeb()->WOW32Reserved), ret );
++                           SELECTOROF(NtCurrentTeb()->SystemReserved1[0]),
++                           OFFSETOF(NtCurrentTeb()->SystemReserved1[0]), ret );
              SYSLEVEL_CheckNotLevel( 2 );
          }
      }
@@ -656,4 +637,3 @@ index 1cc6465f1c6..26cd347f14e 100644
  #define GS_OFFSET  0x1d8  /* FIELD_OFFSET(TEB,SystemReserved2) + FIELD_OFFSET(struct x86_thread_data,gs) */
 -- 
 2.13.1
-


### PR DESCRIPTION
Allows the patch to be applied. Don't know if the code modification was correct but the patch now will apply during installation.