### PR TITLE
Update 0010-tools-winebuild-Add-syscall-thunks-for-64-bit.patch

### DIFF
--- a/patches/winebuild-Fake_Dlls/0010-tools-winebuild-Add-syscall-thunks-for-64-bit.patch
+++ b/patches/winebuild-Fake_Dlls/0010-tools-winebuild-Add-syscall-thunks-for-64-bit.patch
@@ -64,16 +64,16 @@ diff --git a/dlls/ntdll/thread.c b/dlls/ntdll/thread.c
 index 86e5047facb..8b9df0cc7c0 100644
 --- a/dlls/ntdll/thread.c
 +++ b/dlls/ntdll/thread.c
-@@ -55,6 +55,8 @@ static struct _KUSER_SHARED_DATA user_shared_data_internal;
+@@ -59,6 +59,8 @@ static struct _KUSER_SHARED_DATA user_sh
  struct _KUSER_SHARED_DATA *user_shared_data_external;
  struct _KUSER_SHARED_DATA *user_shared_data = &user_shared_data_internal;
  
 +extern void DECLSPEC_NORETURN __wine_syscall_dispatcher( void );
 +
  PUNHANDLED_EXCEPTION_FILTER unhandled_exception_filter = NULL;
- LPTHREAD_START_ROUTINE kernel32_start_process = NULL;
+ void (WINAPI *kernel32_start_process)(LPTHREAD_START_ROUTINE,void*) = NULL;
  
-@@ -84,7 +86,6 @@ static RTL_CRITICAL_SECTION_DEBUG critsect_debug =
+@@ -89,7 +91,6 @@ static RTL_CRITICAL_SECTION_DEBUG critse
  };
  static RTL_CRITICAL_SECTION peb_lock = { &critsect_debug, -1, 0, 0, 0, 0 };
  
@@ -81,7 +81,7 @@ index 86e5047facb..8b9df0cc7c0 100644
  BOOL read_process_time(int unix_pid, int unix_tid, unsigned long clk_tck,
                         LARGE_INTEGER *kernel, LARGE_INTEGER *user)
  {
-@@ -490,6 +491,10 @@ HANDLE thread_init(void)
+@@ -497,6 +498,10 @@ HANDLE thread_init(void)
      InitializeListHead( &ldr.InInitializationOrderModuleList );
      *(ULONG_PTR *)peb->Reserved = get_image_addr();
  
@@ -390,4 +390,3 @@ index 6b6f4afae77..e7ae6f6eaee 100644
      else
 -- 
 2.14.1
-


### PR DESCRIPTION
Allows the patch to be applied