### PR TITLE
Update 0001-wined3d-Use-OpenGL-core-context-for-D3D10-11-when-ne.patch

### DIFF
--- a/patches/wined3d-Core_Context/0001-wined3d-Use-OpenGL-core-context-for-D3D10-11-when-ne.patch
+++ b/patches/wined3d-Core_Context/0001-wined3d-Use-OpenGL-core-context-for-D3D10-11-when-ne.patch
@@ -13,89 +13,27 @@ diff --git a/dlls/dxgi/factory.c b/dlls/dxgi/factory.c
 index c218276a220..49c0a10a95d 100644
 --- a/dlls/dxgi/factory.c
 +++ b/dlls/dxgi/factory.c
-@@ -318,7 +318,7 @@ static HRESULT dxgi_factory_init(struct dxgi_factory *factory, BOOL extended)
+@@ -562,7 +562,7 @@ static HRESULT dxgi_factory_init(struct
      wined3d_private_store_init(&factory->private_store);
  
      wined3d_mutex_lock();
--    factory->wined3d = wined3d_create(WINED3D_FORWARD_DEPTH_BIAS);
+-    factory->wined3d = wined3d_create(0);
 +    factory->wined3d = wined3d_create(WINED3D_FORWARD_DEPTH_BIAS | WINED3D_REQUEST_D3D10);
      wined3d_mutex_unlock();
      if (!factory->wined3d)
      {
-diff --git a/dlls/wined3d/directx.c b/dlls/wined3d/directx.c
-index 68d7e8cba0f..ea70b4b27cb 100644
---- a/dlls/wined3d/directx.c
-+++ b/dlls/wined3d/directx.c
-@@ -6522,6 +6522,18 @@ static void wined3d_adapter_init_fb_cfgs(struct wined3d_adapter *adapter, HDC dc
-     }
- }
- 
-+static BOOL has_extension(const char *list, const char *ext)
-+{
-+    size_t len = strlen(ext);
-+    while (list)
-+    {
-+        while (*list == ' ') list++;
-+        if (!strncmp(list, ext, len) && (!list[len] || list[len] == ' ')) return TRUE;
-+        list = strchr(list, ' ');
-+    }
-+    return FALSE;
-+}
-+
- static BOOL wined3d_adapter_init(struct wined3d_adapter *adapter, UINT ordinal, DWORD wined3d_creation_flags)
- {
-     static const DWORD supported_gl_versions[] =
-@@ -6531,8 +6543,9 @@ static BOOL wined3d_adapter_init(struct wined3d_adapter *adapter, UINT ordinal,
-     };
-     struct wined3d_gl_info *gl_info = &adapter->gl_info;
-     struct wined3d_caps_gl_ctx caps_gl_ctx = {0};
--    unsigned int i;
-+    DWORD max_gl_version = wined3d_settings.max_gl_version;
-     DISPLAY_DEVICEW display_device;
-+    unsigned int i;
- 
-     TRACE("adapter %p, ordinal %u.\n", adapter, ordinal);
- 
-@@ -6577,15 +6590,25 @@ static BOOL wined3d_adapter_init(struct wined3d_adapter *adapter, UINT ordinal,
-         return FALSE;
-     }
- 
-+    if (wined3d_creation_flags & WINED3D_REQUEST_D3D10)
-+    {
-+        const char *gl_extensions = (const char *)gl_info->gl_ops.gl.p_glGetString(GL_EXTENSIONS);
-+        if (!has_extension(gl_extensions, "GL_ARB_compatibility"))
-+        {
-+            ERR_(winediag)("GL_ARB_compatibility not supported, requesting context with GL version 3.2.\n");
-+            max_gl_version = MAKEDWORD_VERSION(3, 2);
-+        }
-+    }
-+
-     for (i = 0; i < ARRAY_SIZE(supported_gl_versions); ++i)
-     {
--        if (supported_gl_versions[i] <= wined3d_settings.max_gl_version)
-+        if (supported_gl_versions[i] <= max_gl_version)
-             break;
-     }
-     if (i == ARRAY_SIZE(supported_gl_versions))
-     {
-         ERR_(winediag)("Requested invalid GL version %u.%u.\n",
--                wined3d_settings.max_gl_version >> 16, wined3d_settings.max_gl_version & 0xffff);
-+                max_gl_version >> 16, max_gl_version & 0xffff);
-         i = ARRAY_SIZE(supported_gl_versions) - 1;
-     }
- 
 diff --git a/include/wine/wined3d.h b/include/wine/wined3d.h
 index 90862d61535..11a5bc4e933 100644
 --- a/include/wine/wined3d.h
 +++ b/include/wine/wined3d.h
-@@ -1312,6 +1312,7 @@ enum wined3d_shader_byte_code_format
+@@ -1310,6 +1310,8 @@ enum wined3d_shader_byte_code_format
  #define WINED3D_NO_PRIMITIVE_RESTART                            0x00000800
  #define WINED3D_LEGACY_CUBEMAP_FILTERING                        0x00001000
- #define WINED3D_FORWARD_DEPTH_BIAS                              0x00002000
+ #define WINED3D_NORMALIZED_DEPTH_BIAS                           0x00002000
++#define WINED3D_FORWARD_DEPTH_BIAS                              0x00002000
 +#define WINED3D_REQUEST_D3D10                                   0x00004000
  
  #define WINED3D_RESZ_CODE                                       0x7fa05000
  
 -- 
 2.13.1
-


### PR DESCRIPTION
Allows the patch to be applied