### PR TITLE
ntdll-User_Shared_Data: 0004-ntdll-tests-test-updating-tickcount fix …

### DIFF
--- a/patches/ntdll-User_Shared_Data/0004-ntdll-tests-Test-updating-TickCount-in-user_shared_d.patch
+++ b/patches/ntdll-User_Shared_Data/0004-ntdll-tests-Test-updating-TickCount-in-user_shared_d.patch
@@ -21,6 +21,14 @@ index b684bc1980d..f90ac6ff91c 100644
  
  #define TICKSPERSEC        10000000
  #define TICKSPERMSEC       10000
+@@ -29,6 +29,7 @@ static VOID (WINAPI *pRtlTimeFieldsToTime)(  PTIME_FIELDS TimeFields,  PLARGE_IN
+ static NTSTATUS (WINAPI *pNtQueryPerformanceCounter)( LARGE_INTEGER *counter, LARGE_INTEGER *frequency );
+ static NTSTATUS (WINAPI *pRtlQueryTimeZoneInformation)( RTL_TIME_ZONE_INFORMATION *);
+ static NTSTATUS (WINAPI *pRtlQueryDynamicTimeZoneInformation)( RTL_DYNAMIC_TIME_ZONE_INFORMATION *);
++static ULONG (WINAPI *pNtGetTickCount)(void);
+ 
+ static const int MonthLengths[2][12] =
+ {
 @@ -153,12 +155,36 @@ static void test_RtlQueryTimeZoneInforma
         wine_dbgstr_w(tzinfo.DaylightName));
  }


### PR DESCRIPTION
fixes missing pNtGetTickCount and allows ntdll-User_Shared_Data to apply and compile. safely compiles allowing these patchsets to work:
ntdll-User_Shared_Data  ntdll-WRITECOPY  ntdll-Signal_Handler  ntdll-Builtin_Prot