### PR TITLE
Update 0001-wined3d-Allow-arbitrary-viewports-for-d3d11.patch

### DIFF
--- a/patches/wined3d-Viewports/0001-wined3d-Allow-arbitrary-viewports-for-d3d11.patch
+++ b/patches/wined3d-Viewports/0001-wined3d-Allow-arbitrary-viewports-for-d3d11.patch
@@ -169,7 +169,6 @@ diff --git a/include/wine/wined3d.h b/include/wine/wined3d.h
 index f468e307b36..4a6b9ff7f3d 100644
 --- a/include/wine/wined3d.h
 +++ b/include/wine/wined3d.h
-@@ -1310,6 +1310,7 @@ enum wined3d_shader_byte_code_format
 @@ -1312,6 +1312,7 @@ enum wined3d_shader_byte_code_format
  #define WINED3D_NORMALIZED_DEPTH_BIAS                           0x00002000
  #define WINED3D_FORWARD_DEPTH_BIAS                              0x00002000

--- a/patches/wined3d-Viewports/0001-wined3d-Allow-arbitrary-viewports-for-d3d11.patch
+++ b/patches/wined3d-Viewports/0001-wined3d-Allow-arbitrary-viewports-for-d3d11.patch
@@ -16,7 +16,7 @@ diff --git a/dlls/d3d11/tests/d3d11.c b/dlls/d3d11/tests/d3d11.c
 index 06708b5f2b4..9795a2c68ba 100644
 --- a/dlls/d3d11/tests/d3d11.c
 +++ b/dlls/d3d11/tests/d3d11.c
-@@ -21113,6 +21113,60 @@ static void test_fractional_viewports(void)
+@@ -23822,6 +23822,60 @@ static void test_fractional_viewports(vo
      release_test_context(&test_context);
  }
  
@@ -77,14 +77,14 @@ index 06708b5f2b4..9795a2c68ba 100644
  static void test_early_depth_stencil(void)
  {
      ID3D11DepthStencilState *depth_stencil_state;
-@@ -21486,6 +21540,7 @@ START_TEST(d3d11)
-     test_gather();
+@@ -25805,6 +25859,7 @@ START_TEST(d3d11)
      test_gather_c();
+     test_depth_bias();
      test_fractional_viewports();
 +    test_negative_viewports();
      test_early_depth_stencil();
      test_conservative_depth_output();
- }
+     test_format_compatibility();
 diff --git a/dlls/d3d8/directx.c b/dlls/d3d8/directx.c
 index 24bd8315983..491efea31e2 100644
 --- a/dlls/d3d8/directx.c
@@ -102,12 +102,12 @@ diff --git a/dlls/d3d9/directx.c b/dlls/d3d9/directx.c
 index fe7163fa88a..c1389529588 100644
 --- a/dlls/d3d9/directx.c
 +++ b/dlls/d3d9/directx.c
-@@ -580,7 +580,7 @@ BOOL d3d9_init(struct d3d9 *d3d9, BOOL extended)
- {
+@@ -579,7 +579,7 @@ BOOL d3d9_init(struct d3d9 *d3d9, BOOL e
      DWORD flags = WINED3D_PRESENT_CONVERSION | WINED3D_HANDLE_RESTORE | WINED3D_PIXEL_CENTER_INTEGER
              | WINED3D_SRGB_READ_WRITE_CONTROL | WINED3D_LEGACY_UNBOUND_RESOURCE_COLOR
--            | WINED3D_NO_PRIMITIVE_RESTART | WINED3D_LEGACY_CUBEMAP_FILTERING;
-+            | WINED3D_NO_PRIMITIVE_RESTART | WINED3D_LEGACY_CUBEMAP_FILTERING | WINED3D_LIMIT_VIEWPORT;
+             | WINED3D_NO_PRIMITIVE_RESTART | WINED3D_LEGACY_CUBEMAP_FILTERING
+-            | WINED3D_NORMALIZED_DEPTH_BIAS;
++            | WINED3D_NORMALIZED_DEPTH_BIAS | WINED3D_LIMIT_VIEWPORT;
  
      if (!extended)
          flags |= WINED3D_VIDMEM_ACCOUNTING;
@@ -170,7 +170,8 @@ index f468e307b36..4a6b9ff7f3d 100644
 --- a/include/wine/wined3d.h
 +++ b/include/wine/wined3d.h
 @@ -1310,6 +1310,7 @@ enum wined3d_shader_byte_code_format
- #define WINED3D_LEGACY_CUBEMAP_FILTERING                        0x00001000
+@@ -1312,6 +1312,7 @@ enum wined3d_shader_byte_code_format
+ #define WINED3D_NORMALIZED_DEPTH_BIAS                           0x00002000
  #define WINED3D_FORWARD_DEPTH_BIAS                              0x00002000
  #define WINED3D_REQUEST_D3D10                                   0x00004000
 +#define WINED3D_LIMIT_VIEWPORT                                  0x00008000
@@ -179,4 +180,3 @@ index f468e307b36..4a6b9ff7f3d 100644
  
 -- 
 2.14.1
-


### PR DESCRIPTION
allows the patch file to be applied