### PR TITLE
Update 0004-wined3d-Fix-calculation-of-normal-when-vertex-blendi.patch

### DIFF
--- a/patches/wined3d-Indexed_Vertex_Blending/0004-wined3d-Fix-calculation-of-normal-when-vertex-blendi.patch
+++ b/patches/wined3d-Indexed_Vertex_Blending/0004-wined3d-Fix-calculation-of-normal-when-vertex-blendi.patch
@@ -25,7 +25,7 @@ diff --git a/dlls/wined3d/glsl_shader.c b/dlls/wined3d/glsl_shader.c
 index 3e84ad0d717..2aa0d0db0a4 100644
 --- a/dlls/wined3d/glsl_shader.c
 +++ b/dlls/wined3d/glsl_shader.c
-@@ -145,8 +145,8 @@ struct glsl_vs_program
+@@ -144,8 +144,8 @@ struct glsl_vs_program
      GLint pos_fixup_location;
  
      GLint modelview_matrix_location[MAX_VERTEX_INDEX_BLENDS];
@@ -35,8 +35,8 @@ index 3e84ad0d717..2aa0d0db0a4 100644
      GLint texture_matrix_location[MAX_TEXTURES];
      GLint material_ambient_location;
      GLint material_diffuse_location;
-@@ -1496,33 +1496,6 @@ static BOOL invert_matrix(struct wined3d_matrix *out, struct wined3d_matrix *m)
-     return TRUE;
+@@ -1523,33 +1523,6 @@ static void transpose_matrix(struct wine
+     *out = temp;
  }
  
 -static void shader_glsl_ffp_vertex_normalmatrix_uniform(const struct wined3d_context *context,
@@ -69,7 +69,7 @@ index 3e84ad0d717..2aa0d0db0a4 100644
  static void shader_glsl_ffp_vertex_texmatrix_uniform(const struct wined3d_context *context,
          const struct wined3d_state *state, unsigned int tex, struct glsl_shader_prog_link *prog)
  {
-@@ -1715,6 +1688,23 @@ static void shader_glsl_load_color_key_constant(const struct glsl_ps_program *ps
+@@ -1747,6 +1720,23 @@ static void shader_glsl_load_color_key_c
      GL_EXTCALL(glUniform4fv(ps->color_key_location, 2, &float_key[0].r));
  }
  
@@ -93,7 +93,7 @@ index 3e84ad0d717..2aa0d0db0a4 100644
  /* Context activation is done by the caller (state handler). */
  static void shader_glsl_load_constants(void *shader_priv, struct wined3d_context *context,
          const struct wined3d_state *state)
-@@ -1725,6 +1715,7 @@ static void shader_glsl_load_constants(void *shader_priv, struct wined3d_context
+@@ -1757,6 +1747,7 @@ static void shader_glsl_load_constants(v
      const struct wined3d_gl_info *gl_info = context->gl_info;
      struct shader_glsl_priv *priv = shader_priv;
      float position_fixup[4];
@@ -101,7 +101,7 @@ index 3e84ad0d717..2aa0d0db0a4 100644
      DWORD update_mask;
  
      struct glsl_shader_prog_link *prog = ctx_data->glsl_program;
-@@ -1779,7 +1770,9 @@ static void shader_glsl_load_constants(void *shader_priv, struct wined3d_context
+@@ -1811,7 +1802,9 @@ static void shader_glsl_load_constants(v
          GL_EXTCALL(glUniformMatrix4fv(prog->vs.modelview_matrix_location[0], 1, FALSE, &mat._11));
          checkGLcall("glUniformMatrix4fv");
  
@@ -112,18 +112,18 @@ index 3e84ad0d717..2aa0d0db0a4 100644
      }
  
      if (update_mask & WINED3D_SHADER_CONST_FFP_VERTEXBLEND)
-@@ -1794,6 +1787,10 @@ static void shader_glsl_load_constants(void *shader_priv, struct wined3d_context
+@@ -1826,6 +1819,10 @@ static void shader_glsl_load_constants(v
              get_modelview_matrix(context, state, i, &mat);
              GL_EXTCALL(glUniformMatrix4fv(prog->vs.modelview_matrix_location[i], 1, FALSE, &mat._11));
              checkGLcall("glUniformMatrix4fv");
-+
++            
 +            get_normal_matrix(context, &mat, normal);
 +            GL_EXTCALL(glUniformMatrix3fv(prog->vs.normal_matrix_location[i], 1, FALSE, normal));
 +            checkGLcall("glUniformMatrix3fv");
          }
      }
  
-@@ -8551,8 +8548,8 @@ static GLuint shader_glsl_generate_ffp_vertex_shader(struct shader_glsl_priv *pr
+@@ -8809,8 +8806,8 @@ static GLuint shader_glsl_generate_ffp_v
      shader_addline(buffer, "\n");
  
      shader_addline(buffer, "uniform mat4 ffp_modelview_matrix[%u];\n", MAX_VERTEX_INDEX_BLENDS);
@@ -133,7 +133,7 @@ index 3e84ad0d717..2aa0d0db0a4 100644
      shader_addline(buffer, "uniform mat4 ffp_texture_matrix[%u];\n", MAX_TEXTURES);
  
      shader_addline(buffer, "uniform struct\n{\n");
-@@ -8662,17 +8659,10 @@ static GLuint shader_glsl_generate_ffp_vertex_shader(struct shader_glsl_priv *pr
+@@ -8920,17 +8917,10 @@ static GLuint shader_glsl_generate_ffp_v
      shader_addline(buffer, "vec3 normal = vec3(0.0);\n");
      if (settings->normal)
      {
@@ -154,7 +154,7 @@ index 3e84ad0d717..2aa0d0db0a4 100644
          }
  
          if (settings->normalize)
-@@ -9550,8 +9540,12 @@ static void shader_glsl_init_vs_uniform_locations(const struct wined3d_gl_info *
+@@ -9808,8 +9798,12 @@ static void shader_glsl_init_vs_uniform_
          string_buffer_sprintf(name, "ffp_modelview_matrix[%u]", i);
          vs->modelview_matrix_location[i] = GL_EXTCALL(glGetUniformLocation(program_id, name->buffer));
      }
@@ -170,4 +170,3 @@ index 3e84ad0d717..2aa0d0db0a4 100644
          string_buffer_sprintf(name, "ffp_texture_matrix[%u]", i);
 -- 
 2.14.1
-


### PR DESCRIPTION
Allows the patch file to be applied