### PR TITLE
Update 0005-wined3d-Move-matrix-inversion-functions-into-utils.c.patch

### DIFF
--- a/patches/wined3d-Indexed_Vertex_Blending/0005-wined3d-Move-matrix-inversion-functions-into-utils.c.patch
+++ b/patches/wined3d-Indexed_Vertex_Blending/0005-wined3d-Move-matrix-inversion-functions-into-utils.c.patch
@@ -13,7 +13,7 @@ diff --git a/dlls/wined3d/glsl_shader.c b/dlls/wined3d/glsl_shader.c
 index 2aa0d0db0a4..aaca2f63441 100644
 --- a/dlls/wined3d/glsl_shader.c
 +++ b/dlls/wined3d/glsl_shader.c
-@@ -1221,281 +1221,6 @@ static void shader_glsl_load_np2fixup_constants(const struct glsl_ps_program *ps
+@@ -1236,293 +1236,6 @@ static void shader_glsl_load_np2fixup_co
      GL_EXTCALL(glUniform4fv(ps->np2_fixup_location, ps->np2_fixup_info->num_consts, &np2fixup_constants[0].sx));
  }
  
@@ -88,7 +88,7 @@ index 2aa0d0db0a4..aaca2f63441 100644
 -    *b = tmp;
 -}
 -
--static BOOL invert_matrix(struct wined3d_matrix *out, struct wined3d_matrix *m)
+-static BOOL invert_matrix(struct wined3d_matrix *out, const struct wined3d_matrix *m)
 -{
 -    float wtmp[4][8];
 -    float m0, m1, m2, m3, s;
@@ -292,6 +292,18 @@ index 2aa0d0db0a4..aaca2f63441 100644
 -    return TRUE;
 -}
 -
+-static void transpose_matrix(struct wined3d_matrix *out, const struct wined3d_matrix *m)
+-{
+-    struct wined3d_matrix temp;
+-    unsigned int i, j;
+-
+-    for (i = 0; i < 4; ++i)
+-        for (j = 0; j < 4; ++j)
+-            (&temp._11)[4 * j + i] = (&m->_11)[4 * i + j];
+-
+-    *out = temp;
+-}
+-
  static void shader_glsl_ffp_vertex_texmatrix_uniform(const struct wined3d_context *context,
          const struct wined3d_state *state, unsigned int tex, struct glsl_shader_prog_link *prog)
  {
@@ -299,7 +311,7 @@ diff --git a/dlls/wined3d/utils.c b/dlls/wined3d/utils.c
 index 847429511b9..b2effb5c2ec 100644
 --- a/dlls/wined3d/utils.c
 +++ b/dlls/wined3d/utils.c
-@@ -5234,6 +5234,281 @@ void multiply_matrix(struct wined3d_matrix *dst, const struct wined3d_matrix *sr
+@@ -5373,6 +5373,293 @@ void multiply_matrix(struct wined3d_matr
      *dst = tmp;
  }
  
@@ -578,6 +590,18 @@ index 847429511b9..b2effb5c2ec 100644
 +    return TRUE;
 +}
 +
++static void transpose_matrix(struct wined3d_matrix *out, const struct wined3d_matrix *m)
++{
++    struct wined3d_matrix temp;
++    unsigned int i, j;
++
++    for (i = 0; i < 4; ++i)
++        for (j = 0; j < 4; ++j)
++            (&temp._11)[4 * j + i] = (&m->_11)[4 * i + j];
++
++    *out = temp;
++}
++
  DWORD get_flexible_vertex_size(DWORD d3dvtVertexType) {
      DWORD size = 0;
      int i;
@@ -585,15 +609,15 @@ diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
 index 7c20934ad40..08f4f01f7e6 100644
 --- a/dlls/wined3d/wined3d_private.h
 +++ b/dlls/wined3d/wined3d_private.h
-@@ -3889,6 +3889,8 @@ GLenum gl_primitive_type_from_d3d(enum wined3d_primitive_type primitive_type) DE
+@@ -3909,6 +3909,9 @@ GLenum gl_primitive_type_from_d3d(enum w
  /* Math utils */
  void multiply_matrix(struct wined3d_matrix *dest, const struct wined3d_matrix *src1,
          const struct wined3d_matrix *src2) DECLSPEC_HIDDEN;
 +BOOL invert_matrix_3d(struct wined3d_matrix *out, const struct wined3d_matrix *in) DECLSPEC_HIDDEN;
 +BOOL invert_matrix(struct wined3d_matrix *out, struct wined3d_matrix *m) DECLSPEC_HIDDEN;
++void transpose_matrix(struct wined3d_matrix *out, const struct wined3d_matrix *m) DECLSPEC_HIDDEN;
  
  void wined3d_release_dc(HWND window, HDC dc) DECLSPEC_HIDDEN;
  
 -- 
 2.14.1
-


### PR DESCRIPTION
Not only allows the patch to be applied but also moves a new matrix function that's been added after this patch was made to utils.c