### PR TITLE
wined3d-Dual_Source_Blending: 0002-d3d11-tests-add-basic-dual-source …

### DIFF
--- a/patches/wined3d-Dual_Source_Blending/0002-d3d11-tests-Add-basic-dual-source-blend-test.patch
+++ b/patches/wined3d-Dual_Source_Blending/0002-d3d11-tests-Add-basic-dual-source-blend-test.patch
@@ -11,7 +11,7 @@ diff --git a/dlls/d3d11/tests/d3d11.c b/dlls/d3d11/tests/d3d11.c
 index 9795a2c68ba..da4e500f94f 100644
 --- a/dlls/d3d11/tests/d3d11.c
 +++ b/dlls/d3d11/tests/d3d11.c
-@@ -21441,6 +21441,174 @@ static void test_conservative_depth_output(void)
+@@ -25075,6 +25075,174 @@ done:
      release_test_context(&test_context);
  }
  
@@ -185,13 +185,15 @@ index 9795a2c68ba..da4e500f94f 100644
 +
  START_TEST(d3d11)
  {
-     test_create_device();
-@@ -21543,4 +21711,5 @@ START_TEST(d3d11)
+     unsigned int argc, i;
+@@ -25200,6 +25368,7 @@ START_TEST(d3d11)
      test_negative_viewports();
      test_early_depth_stencil();
      test_conservative_depth_output();
 +    test_dual_blending();
- }
+     test_format_compatibility();
+     test_clip_distance();
+     test_combined_clip_and_cull_distances();
 -- 
 2.14.1
 


### PR DESCRIPTION
this fixes patching and compilation for wined3d-Dual_Source_Blending