### PR TITLE
Upstream

### DIFF
--- a/patches/wined3d-GenerateMips/0001-d3d11-tests-Add-basic-test-for-mipmap-level-generati.patch
+++ b/patches/wined3d-GenerateMips/0001-d3d11-tests-Add-basic-test-for-mipmap-level-generati.patch
@@ -11,7 +11,7 @@ diff --git a/dlls/d3d11/tests/d3d11.c b/dlls/d3d11/tests/d3d11.c
 index 3c8ff15d6eb..0dc1c94d883 100644
 --- a/dlls/d3d11/tests/d3d11.c
 +++ b/dlls/d3d11/tests/d3d11.c
-@@ -22062,6 +22062,116 @@ static void test_dual_blending(void)
+@@ -25903,6 +25903,116 @@ static void test_dual_blending(void)
      release_test_context(&test_context);
  }
  
@@ -127,13 +127,14 @@ index 3c8ff15d6eb..0dc1c94d883 100644
 +
  START_TEST(d3d11)
  {
-     test_create_device();
-@@ -22167,4 +22277,5 @@ START_TEST(d3d11)
+     unsigned int argc, i;
+@@ -26031,6 +26141,7 @@ START_TEST(d3d11)
      test_early_depth_stencil();
      test_conservative_depth_output();
      test_dual_blending();
 +    test_mipmap_generation();
- }
+     test_format_compatibility();
+     test_clip_distance();
+     test_combined_clip_and_cull_distances();
 -- 
 2.14.2
-

--- a/patches/wined3d-GenerateMips/0001-d3d11-tests-Add-basic-test-for-mipmap-level-generati.patch
+++ b/patches/wined3d-GenerateMips/0001-d3d11-tests-Add-basic-test-for-mipmap-level-generati.patch
@@ -11,7 +11,7 @@ diff --git a/dlls/d3d11/tests/d3d11.c b/dlls/d3d11/tests/d3d11.c
 index 3c8ff15d6eb..0dc1c94d883 100644
 --- a/dlls/d3d11/tests/d3d11.c
 +++ b/dlls/d3d11/tests/d3d11.c
-@@ -25903,6 +25903,116 @@ static void test_dual_blending(void)
+@@ -25243,6 +25243,116 @@ static void test_dual_blending(void)
      release_test_context(&test_context);
  }
  
@@ -125,10 +125,10 @@ index 3c8ff15d6eb..0dc1c94d883 100644
 +    release_test_context(&test_context);
 +}
 +
+ 
  START_TEST(d3d11)
  {
-     unsigned int argc, i;
-@@ -26031,6 +26141,7 @@ START_TEST(d3d11)
+@@ -25370,6 +25480,7 @@ START_TEST(d3d11)
      test_early_depth_stencil();
      test_conservative_depth_output();
      test_dual_blending();

--- a/patches/wined3d-GenerateMips/0002-wined3d-Implement-generation-of-mip-maps-for-shader-.patch
+++ b/patches/wined3d-GenerateMips/0002-wined3d-Implement-generation-of-mip-maps-for-shader-.patch
@@ -18,25 +18,27 @@ diff --git a/dlls/d3d11/device.c b/dlls/d3d11/device.c
 index f71d4a3e910..bbdc97868db 100644
 --- a/dlls/d3d11/device.c
 +++ b/dlls/d3d11/device.c
-@@ -2466,9 +2466,19 @@ static void STDMETHODCALLTYPE d3d11_immediate_context_ClearDepthStencilView(ID3D
+@@ -2528,14 +2528,18 @@ static void STDMETHODCALLTYPE d3d11_imme
  }
  
  static void STDMETHODCALLTYPE d3d11_immediate_context_GenerateMips(ID3D11DeviceContext *iface,
 -        ID3D11ShaderResourceView *view)
 +        ID3D11ShaderResourceView *shader_view)
  {
--    FIXME("iface %p, view %p stub!\n", iface, view);
+-    struct d3d_shader_resource_view *srv = unsafe_impl_from_ID3D11ShaderResourceView(view);
 +    struct d3d_device *device = device_from_immediate_ID3D11DeviceContext(iface);
 +    struct d3d_shader_resource_view *view = unsafe_impl_from_ID3D11ShaderResourceView(shader_view);
-+
+ 
+-    TRACE("iface %p, view %p.\n", iface, view);
 +    TRACE("iface %p, shader_view %p.\n", iface, shader_view);
 +
 +    if (!view)
 +        return;
-+
-+    wined3d_mutex_lock();
+ 
+     wined3d_mutex_lock();
+-    wined3d_shader_resource_view_generate_mipmaps(srv->wined3d_view);
 +    wined3d_device_generate_mips_view(device->wined3d_device, view->wined3d_view);
-+    wined3d_mutex_unlock();
+     wined3d_mutex_unlock();
  }
  
  static void STDMETHODCALLTYPE d3d11_immediate_context_SetResourceMinLOD(ID3D11DeviceContext *iface,
@@ -73,16 +75,16 @@ diff --git a/dlls/wined3d/cs.c b/dlls/wined3d/cs.c
 index 6b37e9d6f03..70fb19382ea 100644
 --- a/dlls/wined3d/cs.c
 +++ b/dlls/wined3d/cs.c
-@@ -72,6 +72,7 @@ enum wined3d_cs_op
+@@ -73,6 +73,7 @@ enum wined3d_cs_op
      WINED3D_CS_OP_CLEAR_UNORDERED_ACCESS_VIEW,
      WINED3D_CS_OP_COPY_UAV_COUNTER,
-     WINED3D_CS_OP_COPY_SUB_RESOURCE,
+     WINED3D_CS_OP_GENERATE_MIPMAPS,
 +    WINED3D_CS_OP_GENERATE_MIPS,
      WINED3D_CS_OP_STOP,
  };
  
-@@ -433,6 +434,12 @@ struct wined3d_cs_copy_sub_resource
-     struct wined3d_box src_box;
+@@ -435,6 +436,12 @@ struct wined3d_cs_generate_mipmaps
+     struct wined3d_shader_resource_view *view;
  };
  
 +struct wined3d_cs_generate_mips
@@ -94,7 +96,7 @@ index 6b37e9d6f03..70fb19382ea 100644
  struct wined3d_cs_stop
  {
      enum wined3d_cs_op opcode;
-@@ -2500,6 +2507,82 @@ void wined3d_cs_emit_copy_sub_resource(struct wined3d_cs *cs, struct wined3d_res
+@@ -2388,6 +2395,82 @@ void wined3d_cs_emit_generate_mipmaps(st
      cs->ops->submit(cs, WINED3D_CS_QUEUE_DEFAULT);
  }
  
@@ -177,10 +179,10 @@ index 6b37e9d6f03..70fb19382ea 100644
  static void wined3d_cs_emit_stop(struct wined3d_cs *cs)
  {
      struct wined3d_cs_stop *op;
-@@ -2559,6 +2642,7 @@ static void (* const wined3d_cs_op_handlers[])(struct wined3d_cs *cs, const void
+@@ -2448,6 +2531,7 @@ static void (* const wined3d_cs_op_handl
      /* WINED3D_CS_OP_CLEAR_UNORDERED_ACCESS_VIEW */ wined3d_cs_exec_clear_unordered_access_view,
      /* WINED3D_CS_OP_COPY_UAV_COUNTER            */ wined3d_cs_exec_copy_uav_counter,
-     /* WINED3D_CS_OP_COPY_SUB_RESOURCE           */ wined3d_cs_exec_copy_sub_resource,
+     /* WINED3D_CS_OP_GENERATE_MIPMAPS            */ wined3d_cs_exec_generate_mipmaps,
 +    /* WINED3D_CS_OP_GENERATE_MIPS               */ wined3d_cs_exec_generate_mips,
  };
  
@@ -189,8 +191,8 @@ diff --git a/dlls/wined3d/device.c b/dlls/wined3d/device.c
 index 1194513879c..bf17029b89e 100644
 --- a/dlls/wined3d/device.c
 +++ b/dlls/wined3d/device.c
-@@ -4330,6 +4330,13 @@ void CDECL wined3d_device_update_sub_resource(struct wined3d_device *device, str
-     wined3d_cs_emit_update_sub_resource(device->cs, resource, sub_resource_idx, box, data, row_pitch, depth_pitch);
+@@ -4363,6 +4363,13 @@ void CDECL wined3d_device_resolve_sub_re
+             src_texture, src_sub_resource_idx, &src_rect, 0, NULL, WINED3D_TEXF_POINT);
  }
  
 +void CDECL wined3d_device_generate_mips_view(struct wined3d_device *device, struct wined3d_shader_resource_view *view)
@@ -235,19 +237,19 @@ diff --git a/dlls/wined3d/wined3d.spec b/dlls/wined3d/wined3d.spec
 index e4d5f2ed9ac..22c76a49281 100644
 --- a/dlls/wined3d/wined3d.spec
 +++ b/dlls/wined3d/wined3d.spec
-@@ -52,6 +52,7 @@
+@@ -55,6 +55,7 @@
  @ cdecl wined3d_device_end_scene(ptr)
  @ cdecl wined3d_device_end_stateblock(ptr ptr)
  @ cdecl wined3d_device_evict_managed_resources(ptr)
 +@ cdecl wined3d_device_generate_mips_view(ptr ptr)
  @ cdecl wined3d_device_get_available_texture_mem(ptr)
  @ cdecl wined3d_device_get_base_vertex_index(ptr)
- @ cdecl wined3d_device_get_clip_plane(ptr long ptr)
+ @ cdecl wined3d_device_get_blend_state(ptr)
 diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
 index 81628d21e8f..4960b513931 100644
 --- a/dlls/wined3d/wined3d_private.h
 +++ b/dlls/wined3d/wined3d_private.h
-@@ -3195,6 +3195,7 @@ void wined3d_texture_bind(struct wined3d_texture *texture,
+@@ -3234,6 +3234,7 @@ void wined3d_texture_bind(struct wined3d
          struct wined3d_context *context, BOOL srgb) DECLSPEC_HIDDEN;
  void wined3d_texture_bind_and_dirtify(struct wined3d_texture *texture,
          struct wined3d_context *context, BOOL srgb) DECLSPEC_HIDDEN;
@@ -255,10 +257,10 @@ index 81628d21e8f..4960b513931 100644
  HRESULT wined3d_texture_check_box_dimensions(const struct wined3d_texture *texture,
          unsigned int level, const struct wined3d_box *box) DECLSPEC_HIDDEN;
  GLenum wined3d_texture_get_gl_buffer(const struct wined3d_texture *texture) DECLSPEC_HIDDEN;
-@@ -3574,6 +3575,7 @@ void wined3d_cs_emit_update_sub_resource(struct wined3d_cs *cs, struct wined3d_r
- void wined3d_cs_emit_copy_sub_resource(struct wined3d_cs *cs, struct wined3d_resource *dst_resource,
-         unsigned int dst_sub_resource_idx, const struct wined3d_box *dst_box, struct wined3d_resource *src_resource,
-         unsigned int src_sub_resource_idx, const struct wined3d_box *src_box) DECLSPEC_HIDDEN;
+@@ -3612,6 +3613,7 @@ void wined3d_cs_emit_unload_resource(str
+ void wined3d_cs_emit_update_sub_resource(struct wined3d_cs *cs, struct wined3d_resource *resource,
+         unsigned int sub_resource_idx, const struct wined3d_box *box, const void *data, unsigned int row_pitch,
+         unsigned int slice_pitch) DECLSPEC_HIDDEN;
 +void wined3d_cs_emit_generate_mips(struct wined3d_cs *cs, struct wined3d_shader_resource_view *view) DECLSPEC_HIDDEN;
  void wined3d_cs_init_object(struct wined3d_cs *cs,
          void (*callback)(void *object), void *object) DECLSPEC_HIDDEN;
@@ -277,4 +279,3 @@ index 37aee84308f..961762d2cf0 100644
          unsigned int entry_count, const PALETTEENTRY *entries, struct wined3d_palette **palette);
 -- 
 2.14.1
-

--- a/patches/wined3d-GenerateMips/0003-d3d11-Implement-d3d10_device_GenerateMips.patch
+++ b/patches/wined3d-GenerateMips/0003-d3d11-Implement-d3d10_device_GenerateMips.patch
@@ -11,25 +11,25 @@ diff --git a/dlls/d3d11/device.c b/dlls/d3d11/device.c
 index 22adf361feb..d389c2625a0 100644
 --- a/dlls/d3d11/device.c
 +++ b/dlls/d3d11/device.c
-@@ -7305,7 +7305,17 @@ static void STDMETHODCALLTYPE d3d10_device_ClearDepthStencilView(ID3D10Device1 *
+@@ -7550,12 +7550,16 @@ static void STDMETHODCALLTYPE d3d10_devi
  static void STDMETHODCALLTYPE d3d10_device_GenerateMips(ID3D10Device1 *iface,
-         ID3D10ShaderResourceView *shader_resource_view)
+         ID3D10ShaderResourceView *view)
  {
--    FIXME("iface %p, shader_resource_view %p stub!\n", iface, shader_resource_view);
+-    struct d3d_shader_resource_view *srv = unsafe_impl_from_ID3D10ShaderResourceView(view);
 +    struct d3d_device *device = impl_from_ID3D10Device(iface);
 +    struct d3d_shader_resource_view *view = unsafe_impl_from_ID3D10ShaderResourceView(shader_resource_view);
-+
+ 
+-    TRACE("iface %p, view %p.\n", iface, view);
 +    TRACE("iface %p, shader_resource_view %p.\n", iface, shader_resource_view);
 +
 +    if (!view)
 +        return;
-+
-+    wined3d_mutex_lock();
+ 
+     wined3d_mutex_lock();
+-    wined3d_shader_resource_view_generate_mipmaps(srv->wined3d_view);
 +    wined3d_device_generate_mips_view(device->wined3d_device, view->wined3d_view);
-+    wined3d_mutex_unlock();
+     wined3d_mutex_unlock();
  }
  
- static void STDMETHODCALLTYPE d3d10_device_ResolveSubresource(ID3D10Device1 *iface,
 -- 
 2.14.1
-

--- a/patches/wined3d-GenerateMips/0003-d3d11-Implement-d3d10_device_GenerateMips.patch
+++ b/patches/wined3d-GenerateMips/0003-d3d11-Implement-d3d10_device_GenerateMips.patch
@@ -11,23 +11,21 @@ diff --git a/dlls/d3d11/device.c b/dlls/d3d11/device.c
 index 22adf361feb..d389c2625a0 100644
 --- a/dlls/d3d11/device.c
 +++ b/dlls/d3d11/device.c
-@@ -7550,12 +7550,16 @@ static void STDMETHODCALLTYPE d3d10_devi
+@@ -4251,12 +4251,16 @@ static void STDMETHODCALLTYPE d3d10_device_ClearDepthStencilView(ID3D10Device1 *
  static void STDMETHODCALLTYPE d3d10_device_GenerateMips(ID3D10Device1 *iface,
          ID3D10ShaderResourceView *view)
  {
--    struct d3d_shader_resource_view *srv = unsafe_impl_from_ID3D10ShaderResourceView(view);
 +    struct d3d_device *device = impl_from_ID3D10Device(iface);
-+    struct d3d_shader_resource_view *view = unsafe_impl_from_ID3D10ShaderResourceView(shader_resource_view);
+     struct d3d_shader_resource_view *srv = unsafe_impl_from_ID3D10ShaderResourceView(view);
  
--    TRACE("iface %p, view %p.\n", iface, view);
-+    TRACE("iface %p, shader_resource_view %p.\n", iface, shader_resource_view);
-+
-+    if (!view)
+     TRACE("iface %p, view %p.\n", iface, view);
+ 
++    if (!srv)
 +        return;
- 
++
      wined3d_mutex_lock();
 -    wined3d_shader_resource_view_generate_mipmaps(srv->wined3d_view);
-+    wined3d_device_generate_mips_view(device->wined3d_device, view->wined3d_view);
++    wined3d_device_generate_mips_view(device->wined3d_device, srv->wined3d_view);
      wined3d_mutex_unlock();
  }
  


### PR DESCRIPTION
This fixes the GenerateMips patchset, but it requires 1DTextures to be fixed before it can be used because patch 0002 needs WINED3D_RTYPE_TEXTURE_1D.

Also patchinstall.sh needs to be changed so that wined3d-GenerateMips requires wined3d-1DTextures