### PR TITLE
(fix incl.) Battle.net crashes after commit 9999806

### DIFF
--- a/patches/bcrypt-Improvements/0033-bcrypt-Implement-importing-of-ecdsa-keys.patch
+++ b/patches/bcrypt-Improvements/0033-bcrypt-Implement-importing-of-ecdsa-keys.patch
@@ -5,10 +5,10 @@ Subject: [PATCH 32/36] bcrypt: Implement importing of ecdsa keys.
 
 ---
  dlls/bcrypt/bcrypt.spec    |   4 +-
- dlls/bcrypt/bcrypt_main.c  | 161 +++++++++++++++++++++++++++++++++++++++++++--
+ dlls/bcrypt/bcrypt_main.c  | 167 +++++++++++++++++++++++++++++++++++++++++++--
  dlls/bcrypt/tests/bcrypt.c |   6 +-
  include/bcrypt.h           |   2 +
- 4 files changed, 163 insertions(+), 10 deletions(-)
+ 4 files changed, 168 insertions(+), 11 deletions(-)
 
 diff --git a/dlls/bcrypt/bcrypt.spec b/dlls/bcrypt/bcrypt.spec
 index 28c2394ce4..78824d73b3 100644
@@ -176,19 +176,25 @@ index f81597e2c6..503712b4c3 100644
      }
  }
  
-@@ -1211,7 +1268,10 @@ static NTSTATUS key_get_tag( struct key *key, UCHAR *tag, ULONG len )
+@@ -1210,8 +1267,15 @@ static NTSTATUS key_get_tag( struct key *key, UCHAR *tag, ULONG len )
+ 
  static NTSTATUS key_destroy( struct key *key )
  {
-     if (key->u.s.handle) pgnutls_cipher_deinit( key->u.s.handle );
+-    if (key->u.s.handle) pgnutls_cipher_deinit( key->u.s.handle );
 -    heap_free( key->u.s.secret );
-+    if(key_is_symmetric(key))
++    if (key_is_symmetric(key))
++    {
++        if (key->u.s.handle) pgnutls_cipher_deinit( key->u.s.handle );
 +        heap_free( key->u.s.secret );
-+     else
++    }
++    else
++    {
 +        heap_free( key->u.a.pubkey );
++    }
      heap_free( key );
      return STATUS_SUCCESS;
  }
-@@ -1329,7 +1389,10 @@ static NTSTATUS key_destroy( struct key *key )
+@@ -1329,7 +1393,10 @@ static NTSTATUS key_destroy( struct key *key )
  {
      if (key->ref_encrypt) CCCryptorRelease( key->ref_encrypt );
      if (key->ref_decrypt) CCCryptorRelease( key->ref_decrypt );
@@ -200,7 +206,7 @@ index f81597e2c6..503712b4c3 100644
      heap_free( key );
      return STATUS_SUCCESS;
  }
-@@ -1340,6 +1403,12 @@ static NTSTATUS key_symmetric_init( struct key *key, struct algorithm *alg, cons
+@@ -1340,6 +1407,12 @@ static NTSTATUS key_symmetric_init( struct key *key, struct algorithm *alg, cons
      return STATUS_NOT_IMPLEMENTED;
  }
  
@@ -213,7 +219,7 @@ index f81597e2c6..503712b4c3 100644
  static NTSTATUS key_duplicate( struct key *key_orig, struct key *key_copy )
  {
      ERR( "support for keys not available at build time\n" );
-@@ -1522,6 +1591,88 @@ NTSTATUS WINAPI BCryptDuplicateKey( BCRYPT_KEY_HANDLE handle, BCRYPT_KEY_HANDLE
+@@ -1522,6 +1595,88 @@ NTSTATUS WINAPI BCryptDuplicateKey( BCRYPT_KEY_HANDLE handle, BCRYPT_KEY_HANDLE
      return STATUS_SUCCESS;
  }
  

--- a/patches/bcrypt-Improvements/0034-bcrypt-Implement-BCryptVerifySignature-for-ecdsa-sig.patch
+++ b/patches/bcrypt-Improvements/0034-bcrypt-Implement-BCryptVerifySignature-for-ecdsa-sig.patch
@@ -384,8 +384,8 @@ index 503712b4c3..3f4e3b665a 100644
 +
  static NTSTATUS key_destroy( struct key *key )
  {
-     if (key->u.s.handle) pgnutls_cipher_deinit( key->u.s.handle );
-@@ -1454,6 +1768,13 @@ static NTSTATUS key_get_tag( struct key *key, UCHAR *tag, ULONG len )
+     if (key_is_symmetric(key))
+@@ -1458,6 +1772,13 @@ static NTSTATUS key_get_tag( struct key *key, UCHAR *tag, ULONG len )
      return STATUS_NOT_IMPLEMENTED;
  }
  
@@ -399,7 +399,7 @@ index 503712b4c3..3f4e3b665a 100644
  static NTSTATUS key_destroy( struct key *key )
  {
      ERR( "support for keys not available at build time\n" );
-@@ -1664,13 +1985,14 @@ NTSTATUS WINAPI BCryptVerifySignature( BCRYPT_KEY_HANDLE handle, void *padding,
+@@ -1668,13 +1989,14 @@ NTSTATUS WINAPI BCryptVerifySignature( BCRYPT_KEY_HANDLE handle, void *padding,
  {
      struct key *key = handle;
  

--- a/patches/bcrypt-Improvements/0035-bcrypt-Initial-implementation-for-RSA-key-import-and.patch
+++ b/patches/bcrypt-Improvements/0035-bcrypt-Initial-implementation-for-RSA-key-import-and.patch
@@ -215,7 +215,7 @@ index 3f4e3b665a..212b802ac1 100644
      pgnutls_pubkey_deinit( gnutls_key );
      return (ret < 0) ? STATUS_INVALID_SIGNATURE : STATUS_SUCCESS;
  }
-@@ -1975,6 +2056,33 @@ NTSTATUS WINAPI BCryptImportKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HAN
+@@ -1979,6 +2060,33 @@ NTSTATUS WINAPI BCryptImportKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HAN
          *ret_key = key;
          return STATUS_SUCCESS;
      }

--- a/patches/bcrypt-Improvements/0037-bcrypt-Store-full-ECCKEY_BLOB-struct-in-BCryptImport.patch
+++ b/patches/bcrypt-Improvements/0037-bcrypt-Store-full-ECCKEY_BLOB-struct-in-BCryptImport.patch
@@ -36,7 +36,7 @@ index 212b802ac1..d683fca45b 100644
  
      if ((ret = pgnutls_pubkey_import_ecc_raw( *gnutls_key, curve, &x, &y )))
      {
-@@ -2047,7 +2049,7 @@ NTSTATUS WINAPI BCryptImportKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HAN
+@@ -2051,7 +2053,7 @@ NTSTATUS WINAPI BCryptImportKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HAN
              return STATUS_NO_MEMORY;
  
          key->hdr.magic = MAGIC_KEY;


### PR DESCRIPTION
Hi all,

I don't know what is currently the proper way of submitting fixes (not new patches). I hope this could at least be counted as a bug report that someone will look into.

Since commit 99998068380d7c5f714d83f67bc328679709dd6b launching Battle.net results in a crash in gnutls_cipher_deinit called from BCryptDestroyKey (backtrace included). I have analyzed the area and found that before the commit, function key_destroy (after applying all staging patches) looked like this:
```
    if (key_is_symmetric(key))
    {
        if (key->u.s.handle) pgnutls_cipher_deinit( key->u.s.handle );
        heap_free( key->u.s.secret );
    }
    else
    {
        heap_free( key->u.a.pubkey );
    }
    heap_free( key );

```
And after the commit it looks like this:
```
    if (key->u.s.handle) pgnutls_cipher_deinit( key->u.s.handle );
    if(key_is_symmetric(key))
        heap_free( key->u.s.secret );
     else
        heap_free( key->u.a.pubkey );
    heap_free( key );
```
So, pgnutls_cipher_deinit is called for both symmetric and asymmetric keys, using union field specific to symmetric key.

I have moved the call inside the first `if` (so the final function is the same as before), and now Battle.net doesn't crash anymore. I have rebased the fix on current master; I hope it is correct and complete.

Off-topic: huge thanks for your work with maintaining Staging, it was amazing to see how quickly you rebased and cleaned up the patches, and made the project usable once again.

Thank you,
— Maciej

[backtrace.txt](https://github.com/wine-staging/wine-staging/files/1776126/backtrace.txt)
