### PR TITLE
Build error

### DIFF
--- a/patches/Staging/0001-kernel32-Add-winediag-message-to-show-warning-that-t.patch
+++ b/patches/Staging/0001-kernel32-Add-winediag-message-to-show-warning-that-t.patch
@@ -20,7 +20,7 @@ index 0a3fd70..206224f 100644
  
  #ifdef __APPLE__
  extern char **__wine_get_main_environment(void);
-@@ -1091,6 +1092,15 @@ void WINAPI start_process( LPTHREAD_START_ROUTINE entry, PEB *peb )
+@@ -1092,6 +1093,15 @@ void WINAPI start_process( LPTHREAD_START_ROUTINE entry, PEB *peb )
  
      __TRY
      {

--- a/patches/Staging/0001-kernel32-Add-winediag-message-to-show-warning-that-t.patch
+++ b/patches/Staging/0001-kernel32-Add-winediag-message-to-show-warning-that-t.patch
@@ -20,7 +20,7 @@ index 0a3fd70..206224f 100644
  
  #ifdef __APPLE__
  extern char **__wine_get_main_environment(void);
-@@ -1090,6 +1091,15 @@ void WINAPI start_process( LPTHREAD_START_ROUTINE entry, PEB *peb )
+@@ -1091,6 +1092,15 @@ void WINAPI start_process( LPTHREAD_START_ROUTINE entry, PEB *peb )
  
      __TRY
      {


### PR DESCRIPTION
First up, sorry for creating this bogus pull request. I created it because I want to discuss an issue, and the issue tracker of the repo is not open. Please consider opening it.

I've just tried to build wine staging with the latest wine version cloned directly from the wine repo and got the following build error:

```
$ ./patchinstall.sh --all DESTDIR=../../wine
...
Applying /home/laci/download/wine-staging/patches/dwmapi-DwmSetIcon/0001-dwmapi-Add-stubs-for-DwmSetIconicLivePreviewBitmap-a.patch
error: patch failed: dlls/dwmapi/dwmapi.spec:80
error: dlls/dwmapi/dwmapi.spec: patch does not apply
ERROR: Failed to apply patch, aborting!
```
