### PR TITLE
d3d11-Deferred_Context: Fix unset buffer_count in SOSetTargets.

### DIFF
--- a/patches/d3d11-Deferred_Context/0035-d3d11-Implement-SOSetTargets-for-deferred-contexts.patch
+++ b/patches/d3d11-Deferred_Context/0035-d3d11-Implement-SOSetTargets-for-deferred-contexts.patch
@@ -1,14 +1,14 @@
-From 03dc0deedf202014089c67329cdf4796cd723bf0 Mon Sep 17 00:00:00 2001
+From 9226f60a95137ba34ae9060c79f5ffd3dee4763e Mon Sep 17 00:00:00 2001
 From: Johannes Specht <jojos_band@gmx.net>
 Date: Mon, 4 Sep 2017 04:15:31 +0200
 Subject: d3d11: Implement SOSetTargets for deferred contexts.
 
 ---
- dlls/d3d11/device.c | 48 +++++++++++++++++++++++++++++++++++++++++++++---
- 1 file changed, 45 insertions(+), 3 deletions(-)
+ dlls/d3d11/device.c | 49 ++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 46 insertions(+), 3 deletions(-)
 
 diff --git a/dlls/d3d11/device.c b/dlls/d3d11/device.c
-index 34f646231a5..24761aab105 100644
+index c60daf5620..ab7eb4654a 100644
 --- a/dlls/d3d11/device.c
 +++ b/dlls/d3d11/device.c
 @@ -77,6 +77,7 @@ enum deferred_cmd
@@ -63,7 +63,7 @@ index 34f646231a5..24761aab105 100644
              case DEFERRED_DRAW:
              {
                  ID3D11DeviceContext_Draw(iface, call->draw_info.count, call->draw_info.start);
-@@ -4567,10 +4591,28 @@ static void STDMETHODCALLTYPE d3d11_deferred_context_OMSetDepthStencilState(ID3D
+@@ -4585,10 +4609,29 @@ static void STDMETHODCALLTYPE d3d11_deferred_context_OMSetDepthStencilState(ID3D
      call->stencil_state_info.stencil_ref = stencil_ref;
  }
  
@@ -83,6 +83,7 @@ index 34f646231a5..24761aab105 100644
 +        return;
 +
 +    call->cmd = DEFERRED_SOSETTARGETS;
++    call->so_set_targets_info.buffer_count = buffer_count;
 +    call->so_set_targets_info.buffers = (void *)(call + 1);
 +    call->so_set_targets_info.offsets = (void *)&call->so_set_targets_info.buffers[buffer_count];
 +
@@ -96,5 +97,5 @@ index 34f646231a5..24761aab105 100644
  
  static void STDMETHODCALLTYPE d3d11_deferred_context_DrawAuto(ID3D11DeviceContext *iface)
 -- 
-2.14.1
+2.15.1
 


### PR DESCRIPTION
buffer_count is not set anywhere. Fixes crashes with e.g. Assassin's Creed Syndicate.
