### PR TITLE
Added patch to make csmt checkbox work on Staging tab

### DIFF
--- a/patches/patchinstall.sh
+++ b/patches/patchinstall.sh
@@ -8041,13 +8041,15 @@ if test "$enable_winecfg_Staging" -eq 1; then
 	patch_apply winecfg-Staging/0003-winecfg-Add-checkbox-to-enable-disable-EAX-support.patch
 	patch_apply winecfg-Staging/0004-winecfg-Add-checkbox-to-enable-disable-HideWineExpor.patch
 	patch_apply winecfg-Staging/0005-winecfg-Add-option-to-enable-disable-GTK3-theming.patch
-	(
+	patch_apply winecfg-Staging/0006-winecfg-Make-csmt-box-usable.patch
+        (
 		printf '%s\n' '+    { "Michael Müller", "winecfg: Add staging tab for CSMT.", 1 },';
 		printf '%s\n' '+    { "Sebastian Lackner", "winecfg: Add checkbox to enable/disable vaapi GPU decoder.", 1 },';
 		printf '%s\n' '+    { "Mark Harmstone", "winecfg: Add checkbox to enable/disable EAX support.", 1 },';
 		printf '%s\n' '+    { "Sebastian Lackner", "winecfg: Add checkbox to enable/disable HideWineExports registry key.", 1 },';
 		printf '%s\n' '+    { "Michael Müller", "winecfg: Add option to enable/disable GTK3 theming.", 1 },';
-	) >> "$patchlist"
+	        printf '%s\n' '+    { "Sveinar Søpler", "winecfg: Make the csmt checkbox DISABLE csmt.", 1 },';
+        ) >> "$patchlist"
 fi
 
 # Patchset winecfg-Unmounted_Devices

--- a/patches/winecfg-Staging/0006-winecfg-Make-csmt-box-usable.patch
+++ b/patches/winecfg-Staging/0006-winecfg-Make-csmt-box-usable.patch
@@ -10,11 +10,10 @@ Subject: winecfg: Make csmt tickbox disable csmt.
 diff --git a/programs/winecfg/staging.c b/programs/winecfg/staging.c
 --- a/programs/winecfg/staging.c	2018-03-30 15:01:58.347456546 +0200
 +++ b/programs/winecfg/staging.c	2018-03-30 15:06:07.527433177 +0200
-@@ -35,15 +35,22 @@
-  */
+@@ -36,14 +36,22 @@
  static BOOL csmt_get(void)
  {
--    BOOL ret;
+     BOOL ret;
 -    char *value = get_reg_key(config_key, keypath("DllRedirects"), "wined3d", NULL);
 -    ret = (value && !strcmp(value, "wined3d-csmt.dll"));
 -    HeapFree(GetProcessHeap(), 0, value);

--- a/patches/winecfg-Staging/0006-winecfg-Make-csmt-box-usable.patch
+++ b/patches/winecfg-Staging/0006-winecfg-Make-csmt-box-usable.patch
@@ -1,0 +1,56 @@
+From: Sveinar Søpler <cybermax@...ter.no>
+Date: Fri, 30 Mar 2018 15:01:11 +0100
+Subject: winecfg: Make csmt tickbox disable csmt.
+
+---
+ programs/winecfg/staging.c  | 18 ++++++++++++-----
+ programs/winecfg/winecfg.rc |  2 +-
+ 2 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/programs/winecfg/staging.c b/programs/winecfg/staging.c
+--- a/programs/winecfg/staging.c	2018-03-30 15:01:58.347456546 +0200
++++ b/programs/winecfg/staging.c	2018-03-30 15:06:07.527433177 +0200
+@@ -35,15 +35,22 @@
+  */
+ static BOOL csmt_get(void)
+ {
+-    BOOL ret;
+-    char *value = get_reg_key(config_key, keypath("DllRedirects"), "wined3d", NULL);
+-    ret = (value && !strcmp(value, "wined3d-csmt.dll"));
+-    HeapFree(GetProcessHeap(), 0, value);
++    /* Ideally we should read the value of the DWORD key if it exists, incase
++       it's manually edited to "1" or a wrong value. I just cant figure out how */
++    if (reg_key_exists(config_key, keypath("Direct3D"), "csmt"))
++          ret = TRUE;
++    else
++          ret = FALSE;
+     return ret;
+ }
+ static void csmt_set(BOOL status)
+ {
+-    set_reg_key(config_key, keypath("DllRedirects"), "wined3d", status ? "wined3d-csmt.dll" : NULL);
++    if (status != 0)
++    /* Create the reg key to DISABLE csmt */
++         set_reg_key_dword(config_key, keypath("Direct3D"), "csmt", 0);
++    else
++    /* Default csmt is enabled, so we can delete the key to enable it */
++         set_reg_key(config_key, keypath("Direct3D"), "csmt", NULL);
+ }
+ 
+ /*
+diff --git a/programs/winecfg/winecfg.rc b/programs/winecfg/winecfg.rc
+--- a/programs/winecfg/winecfg.rc	2018-03-30 15:01:58.347456546 +0200
++++ b/programs/winecfg/winecfg.rc	2018-03-30 15:06:54.935428730 +0200
+@@ -315,7 +315,7 @@
+ BEGIN
+     GROUPBOX    "Staging settings",IDC_STATIC,8,4,244,210
+     LTEXT       "The following settings are experimental and may break stuff!\nMake sure to reset them again in case of a problem.",IDC_STATIC,16,16,230,16
+-    CONTROL     "Enable &CSMT for better graphic performance",IDC_ENABLE_CSMT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,40,230,8
++    CONTROL     "DISABLE! &CSMT for testing purposes",IDC_ENABLE_CSMT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,40,230,8
+     CONTROL     "Enable &VAAPI as backend for DXVA2 GPU decoding",IDC_ENABLE_VAAPI,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,55,230,8
+     CONTROL     "Enable Environmental Audio E&xtensions (EAX)",IDC_ENABLE_EAX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,70,230,8
+     CONTROL     "&Hide Wine version from applications",IDC_ENABLE_HIDEWINE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,85,230,8
+
+--
+1.0
+


### PR DESCRIPTION
As wined3d-csmt.dll no longer is being produced, the "Enable csmt" checkbox does not do other than write to the registry a value that is not being used, as the .dll is not produced.

I have attempted to write a simple patch that makes the checkbox DISABLE csmt (as it is default enabled) by writing DWORD csmt=0x0 to the registry, and then delete it if the checkbox is cleared.

Probably better ways to do this, and should perhaps check the value in the registry incase it is set to 0x1 manually with a reg edit, as the checkbox will indicate csmt being disabled. Clearing the checkbox will remove the reg-key and make csmt default (enabled) again.

Feel free to fix my code, or integrate that to 0001 patch for a cleaner approach :)