### PR TITLE
Disable legacy Wine Staging CSMT wined3d-csmt.dll redirect to wined3d.dll.

### DIFF
--- a/patches/ntdll-DllRedirects/0004-ntdll-Implement-get_redirect-function.patch
+++ b/patches/ntdll-DllRedirects/0004-ntdll-Implement-get_redirect-function.patch
@@ -129,7 +129,7 @@ index eb27d60..9f536ff 100644
  
      if (!(module = get_module_basename(path, &basename)))
          return ret;
-@@ -531,3 +592,46 @@ enum loadorder get_load_order( const WCHAR *app_name, const WCHAR *path )
+@@ -531,3 +592,52 @@ enum loadorder get_load_order( const WCHAR *app_name, const WCHAR *path )
      RtlFreeHeap( GetProcessHeap(), 0, module );
      return ret;
  }
@@ -143,6 +143,7 @@ index eb27d60..9f536ff 100644
 + */
 +WCHAR* get_redirect( const WCHAR *app_name, const WCHAR *path, BYTE *buffer, ULONG size )
 +{
++    static const WCHAR wine_d3d_csmt[] = { 'w','i','n','e','d','3','d','-','c','s','m','t','.','d','l','l',0 };
 +    WCHAR *ret = NULL;
 +    HANDLE std_key, app_key = 0;
 +    WCHAR *module, *basename;
@@ -174,6 +175,11 @@ index eb27d60..9f536ff 100644
 +
 + done:
 +    RtlFreeHeap( GetProcessHeap(), 0, module );
++    if (ret && !strcmpiW(ret, wine_d3d_csmt))
++    {
++        WARN( "disabling Wine Staging legacy CSMT dll redirect: %s\n", debugstr_w(wine_d3d_csmt) );
++        ret = NULL;
++    }
 +    return ret;
 +}
 diff --git a/dlls/ntdll/ntdll_misc.h b/dlls/ntdll/ntdll_misc.h
@@ -188,6 +194,6 @@ index 561e23f..3c2424c 100644
  
  struct debug_info
  {
--- 
+--
 1.9.1
 


### PR DESCRIPTION
wined3d-csmt.dll libraries will still be present in legacy Wineprefixes
created with earlier Wine Staging versions (2.x).
When Wine Staging 3.x redirects to wined3d-csmt.dll - this will break
wined3d support.