### PR TITLE
server-Realtime_Priority: Add SCHED_IDLE definition for older kernels.

### DIFF
--- a/patches/server-Realtime_Priority/0001-wineserver-Draft-to-implement-priority-levels-throug.patch
+++ b/patches/server-Realtime_Priority/0001-wineserver-Draft-to-implement-priority-levels-throug.patch
@@ -1,7 +1,7 @@
-From 25c2aa22c5e33bfe2860d54a4edc50afd357505b Mon Sep 17 00:00:00 2001
+From a63e92672f972f19fd90d0fafb9b293de24348bf Mon Sep 17 00:00:00 2001
 From: Joakim Hernberg <jhernberg@alchemy.lu>
 Date: Tue, 31 Mar 2015 20:58:20 +0200
-Subject: wineserver: Draft to implement priority levels through POSIX
+Subject: [PATCH] wineserver: Draft to implement priority levels through POSIX
  scheduling policies on linux.
 
 Changes by Sebastian Lackner <sebastian@fds-team.de>:
@@ -12,14 +12,14 @@ Changes by Sebastian Lackner <sebastian@fds-team.de>:
 ---
  server/Makefile.in |   1 +
  server/main.c      |   2 +
- server/scheduler.c | 163 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+ server/scheduler.c | 166 +++++++++++++++++++++++++++++++++++++++++++++++++++++
  server/thread.c    |   3 +
  server/thread.h    |   5 ++
- 5 files changed, 174 insertions(+)
+ 5 files changed, 177 insertions(+)
  create mode 100644 server/scheduler.c
 
 diff --git a/server/Makefile.in b/server/Makefile.in
-index 75ba1997c8..e539110cf3 100644
+index aaaa8d34d5..99e4fd0a26 100644
 --- a/server/Makefile.in
 +++ b/server/Makefile.in
 @@ -30,6 +30,7 @@ C_SRCS = \
@@ -52,10 +52,10 @@ index 7aed338e96..ee8cadde5d 100644
      init_registry();
 diff --git a/server/scheduler.c b/server/scheduler.c
 new file mode 100644
-index 0000000000..2fca966192
+index 0000000000..4a5d82b208
 --- /dev/null
 +++ b/server/scheduler.c
-@@ -0,0 +1,163 @@
+@@ -0,0 +1,166 @@
 +/*
 + * Scheduler priority management
 + *
@@ -91,6 +91,9 @@ index 0000000000..2fca966192
 +#endif
 +#ifndef SCHED_RESET_ON_FORK
 +# define SCHED_RESET_ON_FORK 0x40000000
++#endif
++#ifndef SCHED_IDLE
++ #define SCHED_IDLE 5
 +#endif
 +
 +#include "ntstatus.h"
@@ -220,10 +223,10 @@ index 0000000000..2fca966192
 +
 +#endif
 diff --git a/server/thread.c b/server/thread.c
-index 4a1c99838c..754b6fbd27 100644
+index 46fc9a7850..94a626dea3 100644
 --- a/server/thread.c
 +++ b/server/thread.c
-@@ -490,7 +490,10 @@ static void set_thread_info( struct thread *thread,
+@@ -491,7 +491,10 @@ static void set_thread_info( struct thread *thread,
          if ((req->priority >= min && req->priority <= max) ||
              req->priority == THREAD_PRIORITY_IDLE ||
              req->priority == THREAD_PRIORITY_TIME_CRITICAL)
@@ -235,10 +238,10 @@ index 4a1c99838c..754b6fbd27 100644
              set_error( STATUS_INVALID_PARAMETER );
      }
 diff --git a/server/thread.h b/server/thread.h
-index 9614e2140d..8d075dacb6 100644
+index c1478da7fa..71b31bde02 100644
 --- a/server/thread.h
 +++ b/server/thread.h
-@@ -148,4 +148,9 @@ static inline thread_id_t get_thread_id( struct thread *thread ) { return thread
+@@ -151,4 +151,9 @@ static inline thread_id_t get_thread_id( struct thread *thread ) { return thread
  static inline int get_thread_unix_tid( struct thread *thread ) { return thread->unix_tid; }
  static inline timeout_t get_thread_creation_time( struct thread *thread ) { return thread->creation_time; }
  
@@ -249,5 +252,5 @@ index 9614e2140d..8d075dacb6 100644
 +
  #endif  /* __WINE_SERVER_THREAD_H */
 -- 
-2.11.0
+2.13.6
 


### PR DESCRIPTION
Thanks to Bugzilla user Zhenya for the fix.
Fixes https://bugs.winehq.org/show_bug.cgi?id=44327

Value for SCHED_IDLE was taken from: https://github.com/sysstat/sysstat/commit/40046f9846ece5f01cf53451e95d0f7f84d53989