### PR TITLE
kernelbase: Implement PathCchRemoveBackslash/PathCchRemoveBackslashEx

### DIFF
--- a/patches/kernelbase-PathCchRemoveBackslash/0001-kernelbase-Implement-PathCchRemoveBackslash-PathCchR.patch
+++ b/patches/kernelbase-PathCchRemoveBackslash/0001-kernelbase-Implement-PathCchRemoveBackslash-PathCchR.patch
@@ -1,0 +1,246 @@
+From 20fbeab841a17d1f25f043e8145793d6cb33c363 Mon Sep 17 00:00:00 2001
+From: Julien Schueller <schueller@phimeca.com>
+Date: Wed, 4 Jul 2018 22:35:16 +0200
+Subject: [PATCH] kernelbase: Implement
+ PathCchRemoveBackslash()/PathCchRemoveBackslashEx().
+
+---
+ .../api-ms-win-core-path-l1-1-0.spec          |   4 +-
+ dlls/kernelbase/kernelbase.spec               |   4 +-
+ dlls/kernelbase/path.c                        |  27 ++++
+ dlls/kernelbase/tests/path.c                  | 126 ++++++++++++++++++
+ include/pathcch.h                             |   2 +
+ 5 files changed, 159 insertions(+), 4 deletions(-)
+
+diff --git a/dlls/api-ms-win-core-path-l1-1-0/api-ms-win-core-path-l1-1-0.spec b/dlls/api-ms-win-core-path-l1-1-0/api-ms-win-core-path-l1-1-0.spec
+index 287c5d61d9..5629245e62 100644
+--- a/dlls/api-ms-win-core-path-l1-1-0/api-ms-win-core-path-l1-1-0.spec
++++ b/dlls/api-ms-win-core-path-l1-1-0/api-ms-win-core-path-l1-1-0.spec
+@@ -11,8 +11,8 @@
+ @ stub PathCchCombineEx
+ @ stub PathCchFindExtension
+ @ stub PathCchIsRoot
+-@ stub PathCchRemoveBackslash
+-@ stub PathCchRemoveBackslashEx
++@ stdcall PathCchRemoveBackslash(wstr long) kernelbase.PathCchRemoveBackslash
++@ stdcall PathCchRemoveBackslashEx(wstr long ptr ptr) kernelbase.PathCchRemoveBackslashEx
+ @ stub PathCchRemoveExtension
+ @ stub PathCchRemoveFileSpec
+ @ stub PathCchRenameExtension
+diff --git a/dlls/kernelbase/kernelbase.spec b/dlls/kernelbase/kernelbase.spec
+index fb7fafe47b..d17119101e 100644
+--- a/dlls/kernelbase/kernelbase.spec
++++ b/dlls/kernelbase/kernelbase.spec
+@@ -1040,8 +1040,8 @@
+ # @ stub PathCchCombineEx
+ # @ stub PathCchFindExtension
+ # @ stub PathCchIsRoot
+-# @ stub PathCchRemoveBackslash
+-# @ stub PathCchRemoveBackslashEx
++@ stdcall PathCchRemoveBackslash(wstr long)
++@ stdcall PathCchRemoveBackslashEx(wstr long ptr ptr)
+ # @ stub PathCchRemoveExtension
+ # @ stub PathCchRemoveFileSpec
+ # @ stub PathCchRenameExtension
+diff --git a/dlls/kernelbase/path.c b/dlls/kernelbase/path.c
+index 373c34e979..9ddb337ec9 100644
+--- a/dlls/kernelbase/path.c
++++ b/dlls/kernelbase/path.c
+@@ -65,3 +65,30 @@ HRESULT WINAPI PathCchAddBackslashEx(WCHAR *path, SIZE_T size, WCHAR **endptr, S
+ 
+     return S_OK;
+ }
++
++HRESULT WINAPI PathCchRemoveBackslash(WCHAR *path, SIZE_T size)
++{
++    return PathCchRemoveBackslashEx(path, size, NULL, NULL);
++}
++
++HRESULT WINAPI PathCchRemoveBackslashEx(WCHAR *path, SIZE_T size, WCHAR **endptr, SIZE_T *remaining)
++{
++    BOOL needs_trim;
++    SIZE_T length;
++
++    TRACE("%s, %lu, %p, %p\n", debugstr_w(path), size, endptr, remaining);
++
++    length = strlenW(path);
++    needs_trim = size && length && path[length - 1] == '\\';
++
++    if (needs_trim)
++    {
++        path[length - 1] = 0;
++        --length;
++    }
++
++    if (endptr) *endptr = path + length;
++    if (remaining) *remaining = size - length;
++
++    return needs_trim ? S_OK : S_FALSE;
++}
+diff --git a/dlls/kernelbase/tests/path.c b/dlls/kernelbase/tests/path.c
+index cdba51bf3f..e7f02c43f1 100644
+--- a/dlls/kernelbase/tests/path.c
++++ b/dlls/kernelbase/tests/path.c
+@@ -31,6 +31,8 @@
+ 
+ HRESULT (WINAPI *pPathCchAddBackslash)(WCHAR *out, SIZE_T size);
+ HRESULT (WINAPI *pPathCchAddBackslashEx)(WCHAR *out, SIZE_T size, WCHAR **endptr, SIZE_T *remaining);
++HRESULT (WINAPI *pPathCchRemoveBackslash)(WCHAR *out, SIZE_T size);
++HRESULT (WINAPI *pPathCchRemoveBackslashEx)(WCHAR *out, SIZE_T size, WCHAR **endptr, SIZE_T *remaining);
+ HRESULT (WINAPI *pPathCchCombineEx)(WCHAR *out, SIZE_T size, const WCHAR *path1, const WCHAR *path2, DWORD flags);
+ 
+ static const struct
+@@ -245,6 +247,126 @@ static void test_PathCchAddBackslashEx(void)
+     }
+ }
+ 
++struct removebackslash_test
++{
++    const char *path;
++    const char *result;
++    HRESULT hr;
++    SIZE_T size;
++    SIZE_T remaining;
++};
++
++static const struct removebackslash_test removebackslash_tests[] =
++{
++    { "C:\\",    "C:",    S_OK, MAX_PATH, MAX_PATH - 2 },
++    { "a.txt\\", "a.txt", S_OK, MAX_PATH, MAX_PATH - 5 },
++    { "a/b\\",   "a/b",   S_OK, MAX_PATH, MAX_PATH - 3 },
++};
++
++static void test_PathCchRemoveBackslash(void)
++{
++    WCHAR pathW[MAX_PATH];
++    unsigned int i;
++    HRESULT hr;
++
++    if (!pPathCchRemoveBackslash)
++    {
++        win_skip("PathCchRemoveBackslash() is not available.\n");
++        return;
++    }
++
++    pathW[0] = 0;
++    hr = pPathCchRemoveBackslash(pathW, 0);
++    ok(hr == S_FALSE, "Unexpected hr %#x.\n", hr);
++    ok(pathW[0] == 0, "Unexpected path.\n");
++
++    pathW[0] = 0;
++    hr = pPathCchRemoveBackslash(pathW, 1);
++    ok(hr == S_FALSE, "Unexpected hr %#x.\n", hr);
++    ok(pathW[0] == 0, "Unexpected path.\n");
++
++    pathW[0] = 0;
++    hr = pPathCchRemoveBackslash(pathW, 2);
++    ok(hr == S_FALSE, "Unexpected hr %#x.\n", hr);
++    ok(pathW[0] == 0, "Unexpected path.\n");
++
++    for (i = 0; i < ARRAY_SIZE(removebackslash_tests); i++)
++    {
++        const struct removebackslash_test *test = &removebackslash_tests[i];
++        char path[MAX_PATH];
++
++        MultiByteToWideChar(CP_ACP, 0, test->path, -1, pathW, ARRAY_SIZE(pathW));
++        hr = pPathCchRemoveBackslash(pathW, test->size);
++        ok(hr == test->hr, "%u: unexpected return value %#x.\n", i, hr);
++
++        WideCharToMultiByte(CP_ACP, 0, pathW, -1, path, ARRAY_SIZE(path), NULL, NULL);
++        ok(!strcmp(path, test->result), "%u: unexpected resulting path %s.\n", i, path);
++    }
++}
++
++static void test_PathCchRemoveBackslashEx(void)
++{
++    WCHAR pathW[MAX_PATH];
++    SIZE_T remaining;
++    unsigned int i;
++    HRESULT hr;
++    WCHAR *ptrW;
++
++    if (!pPathCchRemoveBackslashEx)
++    {
++        win_skip("PathCchRemoveBackslashEx() is not available.\n");
++        return;
++    }
++
++    pathW[0] = 0;
++    hr = pPathCchRemoveBackslashEx(pathW, 0, NULL, NULL);
++    ok(hr == S_FALSE, "Unexpected hr %#x.\n", hr);
++    ok(pathW[0] == 0, "Unexpected path.\n");
++
++    pathW[0] = 0;
++    ptrW = (void *)0xdeadbeef;
++    remaining = 123;
++    hr = pPathCchRemoveBackslashEx(pathW, 1, &ptrW, &remaining);
++    ok(hr == S_FALSE, "Unexpected hr %#x.\n", hr);
++    ok(pathW[0] == 0, "Unexpected path.\n");
++    ok(ptrW == pathW, "Unexpected endptr %p.\n", ptrW);
++    ok(remaining == 1, "Unexpected remaining size.\n");
++
++    pathW[0] = 0;
++    hr = pPathCchRemoveBackslashEx(pathW, 2, NULL, NULL);
++    ok(hr == S_FALSE, "Unexpected hr %#x.\n", hr);
++    ok(pathW[0] == 0, "Unexpected path.\n");
++
++    for (i = 0; i < ARRAY_SIZE(removebackslash_tests); i++)
++    {
++        const struct removebackslash_test *test = &removebackslash_tests[i];
++        char path[MAX_PATH];
++
++        MultiByteToWideChar(CP_ACP, 0, test->path, -1, pathW, ARRAY_SIZE(pathW));
++        hr = pPathCchRemoveBackslashEx(pathW, test->size, NULL, NULL);
++        ok(hr == test->hr, "%u: unexpected return value %#x.\n", i, hr);
++
++        WideCharToMultiByte(CP_ACP, 0, pathW, -1, path, ARRAY_SIZE(path), NULL, NULL);
++        ok(!strcmp(path, test->result), "%u: unexpected resulting path %s.\n", i, path);
++
++        ptrW = (void *)0xdeadbeef;
++        remaining = 123;
++        MultiByteToWideChar(CP_ACP, 0, test->path, -1, pathW, ARRAY_SIZE(pathW));
++        hr = pPathCchRemoveBackslashEx(pathW, test->size, &ptrW, &remaining);
++        ok(hr == test->hr, "%u: unexpected return value %#x.\n", i, hr);
++        if (SUCCEEDED(hr))
++        {
++            ok(ptrW == (pathW + lstrlenW(pathW)), "%u: unexpected end pointer.\n", i);
++            ok(remaining == test->remaining, "%u: unexpected remaining buffer length.\n", i);
++        }
++        else
++        {
++            ok(ptrW == NULL, "%u: unexpecred end pointer.\n", i);
++            ok(remaining == 0, "%u: unexpected remaining buffer length.\n", i);
++        }
++    }
++}
++
+ START_TEST(path)
+ {
+     HMODULE hmod = LoadLibraryA("kernelbase.dll");
+@@ -252,8 +374,12 @@ START_TEST(path)
+     pPathCchCombineEx = (void *)GetProcAddress(hmod, "PathCchCombineEx");
+     pPathCchAddBackslash = (void *)GetProcAddress(hmod, "PathCchAddBackslash");
+     pPathCchAddBackslashEx = (void *)GetProcAddress(hmod, "PathCchAddBackslashEx");
++    pPathCchRemoveBackslash = (void *)GetProcAddress(hmod, "PathCchRemoveBackslash");
++    pPathCchRemoveBackslashEx = (void *)GetProcAddress(hmod, "PathCchRemoveBackslashEx");
+ 
+     test_PathCchCombineEx();
+     test_PathCchAddBackslash();
+     test_PathCchAddBackslashEx();
++    test_PathCchRemoveBackslash();
++    test_PathCchRemoveBackslashEx();
+ }
+diff --git a/include/pathcch.h b/include/pathcch.h
+index 2b2aed4c8f..c19ed1d930 100644
+--- a/include/pathcch.h
++++ b/include/pathcch.h
+@@ -25,4 +25,6 @@
+ 
+ HRESULT WINAPI PathCchAddBackslash(WCHAR *path, SIZE_T size);
+ HRESULT WINAPI PathCchAddBackslashEx(WCHAR *path, SIZE_T size, WCHAR **end, SIZE_T *remaining);
++HRESULT WINAPI PathCchRemoveBackslash(WCHAR *path, SIZE_T size);
++HRESULT WINAPI PathCchRemoveBackslashEx(WCHAR *path, SIZE_T size, WCHAR **end, SIZE_T *remaining);
+ HRESULT WINAPI PathCchCombineEx(WCHAR *out, SIZE_T size, const WCHAR *path1, const WCHAR *path2, DWORD flags);
+-- 
+2.18.0
+

--- a/patches/patchinstall.sh
+++ b/patches/patchinstall.sh
@@ -181,6 +181,7 @@ patch_enable_all ()
 	enable_kernel32_SCSI_Sysfs="$1"
 	enable_kernel32_SetFileCompletionNotificationModes="$1"
 	enable_kernelbase_PathCchCombineEx="$1"
+        enable_kernelbase_PathCchRemoveBackSlash="$1"
 	enable_krnl386_exe16_GDT_LDT_Emulation="$1"
 	enable_krnl386_exe16_Invalid_Console_Handles="$1"
 	enable_krnl386_exe16__lclose16="$1"


### PR DESCRIPTION
My goal was first to implement PathCchCombineEx (https://bugs.winehq.org/show_bug.cgi?id=42474), so I figured I would make this first step to see how things are going.
Then I saw there's already a patch here for this issue (semi-stub though), but I figured I'd still submit my first baby steps for review.
I started with this one as I think these path functions are probably dependent on each other somehow, and removebackslash is probably needed by PathCchCombineEx at some point, but I have really no clue how to organize this:
https://github.com/wine-mirror/wine/blob/master/dlls/api-ms-win-core-path-l1-1-0/api-ms-win-core-path-l1-1-0.spec
