### PR TITLE
Update 0001-xaudio2-Use-ffmpeg-to-convert-WMA-formats.patch

### DIFF
--- a/patches/xaudio2_7-WMA_support/0001-xaudio2-Use-ffmpeg-to-convert-WMA-formats.patch
+++ b/patches/xaudio2_7-WMA_support/0001-xaudio2-Use-ffmpeg-to-convert-WMA-formats.patch
@@ -727,5 +727,75 @@ index 8bb581d..1214dfa 100644
  #define  WAVE_FORMAT_CREATIVE_FASTSPEECH8	0x0202	/*  Creative Labs, Inc  */
  #define  WAVE_FORMAT_CREATIVE_FASTSPEECH10	0x0203	/*  Creative Labs, Inc  */
 -- 
+diff --git a/wine-3.12/dlls/xapofx1_1/Makefile.in b/wine-git/dlls/xapofx1_1/Makefile.in
+index f69ff86..5b8d704 100644
+--- a/wine-3.12/dlls/xapofx1_1/Makefile.in
++++ b/wine-git/dlls/xapofx1_1/Makefile.in
+@@ -2,7 +2,8 @@ EXTRADEFS = -DXAPOFX1_VER=1 -DXAUDIO2_VER=2
+ MODULE    = xapofx1_1.dll
+ IMPORTS   = ole32
+ PARENTSRC = ../xaudio2_7
+-
++EXTRALIBS = $(OPENAL_LIBS) $(LIBAVCODEC_LIBS) $(LIBAVUTIL_LIBS)
++EXTRAINCL = $(LIBAVCODEC_CFLAGS) $(LIBAVUTIL_CFLAGS) 
+ C_SRCS = \
+ 	xapofx.c
+ 
+diff --git a/wine-3.12/dlls/xapofx1_2/Makefile.in b/wine-git/dlls/xapofx1_2/Makefile.in
+index d56a2be..29d06e1 100644
+--- a/wine-3.12/dlls/xapofx1_2/Makefile.in
++++ b/wine-git/dlls/xapofx1_2/Makefile.in
+@@ -2,6 +2,7 @@ EXTRADEFS = -DXAPOFX1_VER=2 -DXAUDIO2_VER=3
+ MODULE    = xapofx1_2.dll
+ IMPORTS   = ole32
+ PARENTSRC = ../xaudio2_7
+-
++EXTRALIBS = $(OPENAL_LIBS) $(LIBAVCODEC_LIBS) $(LIBAVUTIL_LIBS)
++EXTRAINCL = $(LIBAVCODEC_CFLAGS) $(LIBAVUTIL_CFLAGS) 
+ C_SRCS = \
+ 	xapofx.c
+
+ 	diff --git a/wine-3.12/dlls/xapofx1_3/Makefile.in b/wine-git/dlls/xapofx1_3/Makefile.in
+index 1139520..49e50f2 100644
+--- a/wine-3.12/dlls/xapofx1_3/Makefile.in
++++ b/wine-git/dlls/xapofx1_3/Makefile.in
+@@ -2,7 +2,8 @@ EXTRADEFS = -DXAPOFX1_VER=3 -DXAUDIO2_VER=4
+ MODULE    = xapofx1_3.dll
+ IMPORTS   = ole32
+ PARENTSRC = ../xaudio2_7
+-
++EXTRALIBS = $(OPENAL_LIBS) $(LIBAVCODEC_LIBS) $(LIBAVUTIL_LIBS)
++EXTRAINCL = $(LIBAVCODEC_CFLAGS) $(LIBAVUTIL_CFLAGS) 
+ C_SRCS = \
+ 	xapofx.c
+ 
+ diff --git a/wine-3.12/dlls/xapofx1_4/Makefile.in b/wine-git/dlls/xapofx1_4/Makefile.in
+index b49e464..2adf148 100644
+--- a/wine-3.12/dlls/xapofx1_4/Makefile.in
++++ b/wine-git/dlls/xapofx1_4/Makefile.in
+@@ -2,6 +2,7 @@ EXTRADEFS = -DXAPOFX1_VER=4 -DXAUDIO2_VER=6
+ MODULE    = xapofx1_4.dll
+ IMPORTS   = ole32
+ PARENTSRC = ../xaudio2_7
+-
++EXTRALIBS = $(OPENAL_LIBS) $(LIBAVCODEC_LIBS) $(LIBAVUTIL_LIBS)
++EXTRAINCL = $(LIBAVCODEC_CFLAGS) $(LIBAVUTIL_CFLAGS) 
+ C_SRCS = \
+ 	xapofx.c
+
+ 	diff --git a/wine-3.12/dlls/xapofx1_5/Makefile.in b/wine-git/dlls/xapofx1_5/Makefile.in
+index 5055a16..273eb9b 100644
+--- a/wine-3.12/dlls/xapofx1_5/Makefile.in
++++ b/wine-git/dlls/xapofx1_5/Makefile.in
+@@ -2,6 +2,7 @@ EXTRADEFS = -DXAPOFX1_VER=5 -DXAUDIO2_VER=7
+ MODULE    = xapofx1_5.dll
+ IMPORTS   = ole32
+ PARENTSRC = ../xaudio2_7
+-
++EXTRALIBS = $(OPENAL_LIBS) $(LIBAVCODEC_LIBS) $(LIBAVUTIL_LIBS)
++EXTRAINCL = $(LIBAVCODEC_CFLAGS) $(LIBAVUTIL_CFLAGS) 
+ C_SRCS = \
+ 	xapofx.c
+
 2.7.4
 


### PR DESCRIPTION
Seems to fix compile errors on Fedora 28, the patch itself is a mess but it fix the compile error because of missing libavc*