### PR TITLE
add wined3d-setpixelformat to fix #18490

### DIFF
--- a/patches/patchinstall.sh
+++ b/patches/patchinstall.sh
@@ -371,6 +371,7 @@ patch_enable_all ()
 	enable_wined3d_Indexed_Vertex_Blending="$1"
 	enable_wined3d_QUERY_Stubs="$1"
 	enable_wined3d_Silence_FIXMEs="$1"
+	enable_wined3d_setpixelformat="$1"
 	enable_wined3d_UAV_Counters="$1"
 	enable_wined3d_WINED3DFMT_B8G8R8X8_UNORM="$1"
 	enable_wined3d_WINED3D_RS_COLORWRITEENABLE="$1"
@@ -1285,6 +1286,9 @@ patch_enable ()
 			;;
 		wined3d-QUERY_Stubs)
 			enable_wined3d_QUERY_Stubs="$2"
+			;;
+		wined3d-setpixelformat)
+			enable_wined3d-setpixelformat="$2"
 			;;
 		wined3d-Silence_FIXMEs)
 			enable_wined3d_Silence_FIXMEs="$2"
@@ -3196,7 +3200,7 @@ fi
 # |   *	[#17913] Port Royale doesn't display ocean correctly
 # |
 # | Modified files:
-# |   *	dlls/wined3d/Makefile.in, dlls/wined3d/dxtn.c, dlls/wined3d/dxtn.h, dlls/wined3d/surface.c, dlls/wined3d/wined3d.spec,
+# |   *	dlls/wined3d/Makefile.in, dlls/wined3d/dxtn.c, dlls/wined3d/dxtn.h, dlls/wined3d/surface.c, dlls/wined3d/wined3d.spec, 
 # | 	include/wine/wined3d.h
 # |
 if test "$enable_wined3d_DXTn" -eq 1; then
@@ -7587,6 +7591,15 @@ if test "$enable_wined3d_QUERY_Stubs" -eq 1; then
 	(
 		printf '%s\n' '+    { "Michael Müller", "wined3d: Add stubs for QUERY_TYPE_SO_STATISTICS and QUERY_TYPE_SO_OVERFLOW.", 1 },';
 	) >> "$patchlist"
+fi
+
+# Patchset wined3d-setpixelformat
+# |
+# | Modiefied files: 
+# |   *	dlls/wined3d/context.c
+# |
+if test "$enable_wined3d_setpixelformat" -eq 1; then
+	patch_apply wined3d-setpixelformat/0001-wined3d-setpixelformat.patch
 fi
 
 # Patchset wined3d-Silence_FIXMEs

--- a/patches/wined3d-setpixelformat/0001-wined3d-setpixelformat.patch
+++ b/patches/wined3d-setpixelformat/0001-wined3d-setpixelformat.patch
@@ -1,0 +1,23 @@
+diff --git a/dlls/wined3d/context.c b/dlls/wined3d/context.c
+index 83e3563..abcc95f 100644
+--- a/dlls/wined3d/context.c
++++ b/dlls/wined3d/context.c
+@@ -1929,10 +1929,16 @@ struct wined3d_context *context_create(struct wined3d_swapchain *swapchain,
+         goto out;
+     }
+ 
+-    if (!(context->hdc = GetDCEx(swapchain->win_handle, 0, DCX_USESTYLE | DCX_CACHE)))
+-    {
++    context->hdc = NULL;
++
++   if (swapchain->win_handle == GetDesktopWindow())
++       TRACE("Attempted to retrieve device context of desktop window, trying swapchain backup.\n");
++   else if (!(context->hdc = GetDC(swapchain->win_handle)))
++
+         WARN("Failed to retrieve device context, trying swapchain backup.\n");
+ 
++   if (!context->hdc)
++   {
+         if ((context->hdc = swapchain_get_backup_dc(swapchain)))
+             context->hdc_is_private = TRUE;
+         else

--- a/patches/wined3d-setpixelformat/definition
+++ b/patches/wined3d-setpixelformat/definition
@@ -1,0 +1,1 @@
+Fixes: [18490] fixes a crash in Total War: Empire and Total War: Napoleon


### PR DESCRIPTION
This is a fix for Total War: Empire and Total War: Napoleon; without the patch the game crashes when switching from Campaign mode to Battle mode. Please tell me if you want to accept the patch, so that I can test it with the full staging patchset for conflicts. 