### PR TITLE
winepulse: AudioClock_GetPosition return correct value if position is inferior of a period 

### DIFF
--- a/patches/patchinstall.sh
+++ b/patches/patchinstall.sh
@@ -7525,6 +7525,7 @@ if test "$enable_winepulse_PulseAudio_Support" -eq 1; then
 	patch_apply winepulse-PulseAudio_Support/0008-winepulse-Fix-up-recording.patch
 	patch_apply winepulse-PulseAudio_Support/0009-winepulse.drv-Fix-getting-the-same-timing-info.patch
 	patch_apply winepulse-PulseAudio_Support/0010-winepulse-Update-last-time-on-underrun.patch
+	patch_apply winepulse-PulseAudio_Support/0011-Return-correct-position-when-the-position-is-inferio.patch	
 	(
 		printf '%s\n' '+    { "Sebastian Lackner", "winepulse.drv: Use a separate mainloop and ctx for pulse_test_connect.", 1 },';
 		printf '%s\n' '+    { "Andrew Eikum", "winepulse: Don'\''t rely on pulseaudio callbacks for timing.", 1 },';
@@ -7536,6 +7537,7 @@ if test "$enable_winepulse_PulseAudio_Support" -eq 1; then
 		printf '%s\n' '+    { "Andrew Eikum", "winepulse: Fix up recording.", 1 },';
 		printf '%s\n' '+    { "Zhiyi Zhang", "winepulse.drv: Fix getting the same timing info.", 1 },';
 		printf '%s\n' '+    { "Andrew Eikum", "winepulse: Update last time on underrun.", 1 },';
+		printf '%s\n' '+    { "Lorenzo Ferrillo","winepulse: Return correct position when the position is inferior to a  period.", 1 },';		
 	) >> "$patchlist"
 fi
 

--- a/patches/winepulse-PulseAudio_Support/0011-Return-correct-position-when-the-position-is-inferio.patch
+++ b/patches/winepulse-PulseAudio_Support/0011-Return-correct-position-when-the-position-is-inferio.patch
@@ -1,0 +1,28 @@
+From 79afe407ea3e0a5496f6a4e488785cc73d1c3a5d Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Sat, 10 Nov 2018 01:22:09 +0100
+Subject: Return correct position when the position is inferior to a  period
+
+Signed-off-by: llde <lorenzofersteam@live.it>
+---
+ dlls/winepulse.drv/mmdevdrv.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/dlls/winepulse.drv/mmdevdrv.c b/dlls/winepulse.drv/mmdevdrv.c
+index fb2e3678f8..d578031c63 100644
+--- a/dlls/winepulse.drv/mmdevdrv.c
++++ b/dlls/winepulse.drv/mmdevdrv.c
+@@ -2770,9 +2770,7 @@ static HRESULT WINAPI AudioClock_GetPosition(IAudioClock *iface, UINT64 *pos,
+     *pos = This->clock_written - This->held_bytes;
+ 
+     if(This->started){
+-        if(*pos < This->period_bytes)
+-            *pos = 0;
+-        else if(This->held_bytes > This->period_bytes)
++        if(This->held_bytes > This->period_bytes)
+             *pos -= This->period_bytes;
+     }
+ 
+-- 
+2.19.1
+

--- a/patches/winepulse-PulseAudio_Support/definition
+++ b/patches/winepulse-PulseAudio_Support/definition
@@ -6,3 +6,5 @@ Fixes: Use actual program name if available to describe PulseAudio streams
 Fixes: Expose PKEY_AudioEndpoint_PhysicalSpeakers device property in PulseAudio driver
 # Patches 0002, 0008-0010 fix the following bug:
 Fixes: [28282] Sound constantly crackling in a lot of games
+# Patch 0011 fix the following bug introduced with Patch 0002
+Fixes: [46104] winepulse-PulseAudio_Support patch cause application to hang with native dsound.dll


### PR DESCRIPTION
Hi.
I discovered that the winepulse-PulseAudio_Support 0002 subpatch (winepulse: Don't rely on pulseaudio callbacks for timing) broke applications that require native dsound.dll (all DirectMusic application for example), breaking the expected return value of AudioClock_GetPosition is some conditions.

I wanted initially to edit directly the 0002 patch, but I  wasn't able to bend git to my will, so I created a new patch and inserted it in the patchset.
A precisation: when I say correct value in the title, I mean the value that is returned by the function prior applying the 0002 patchset.

I'm sorry if this isn't the correct way to submit patch, but the Contributing.md in the repo is outdated, and the wiki, doesn't specify what to do with patches the fix a bug introduced by a wine-staging patch.

This is the bug-report with my analysis of the bug:
https://bugs.winehq.org/show_bug.cgi?id=46104

Thanks.