### PR TITLE
Use /usr/bin/env python2 instead of /usr/bin/python2

### DIFF
--- a/staging/newupdate.py
+++ b/staging/newupdate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import getopt, os, subprocess, sys
 

--- a/staging/patchgraph.py
+++ b/staging/patchgraph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # Plot dependency graph for Staging patches.

--- a/staging/patchupdate.py
+++ b/staging/patchupdate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # Automatic patch dependency checker and apply script generator.

--- a/staging/patchutils.py
+++ b/staging/patchutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 #
 # Python functions to read, split and apply patches.
 #

--- a/staging/progressbar.py
+++ b/staging/progressbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 #
 # Python progressbar functions.
 #


### PR DESCRIPTION
Signed-off-by: James Larrowe <larrowe.semaj11@gmail.com>

Fix an issue where `/usr/bin/python2` doesn't exist, e.g if it is `/usr/local/bin/python2`