### PR TITLE
DrawText patchset, pass D3DUSAGE_DYNAMIC to CreateTexture

### DIFF
--- a/patches/d3dx9_36-DrawText/0001-d3dx9_36-Implement-ID3DXFontImpl_DrawText.patch
+++ b/patches/d3dx9_36-DrawText/0001-d3dx9_36-Implement-ID3DXFontImpl_DrawText.patch
@@ -180,7 +180,7 @@ index 5522dea..916ce4c 100644
 +                DeleteObject(This->bitmap);
 +            }
 +
-+            hr = D3DXCreateTexture(This->device, This->tex_width, This->tex_height, 1, 0,
++            hr = D3DXCreateTexture(This->device, This->tex_width, This->tex_height, 1, D3DUSAGE_DYNAMIC,
 +                                   D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &This->texture);
 +            if (FAILED(hr))
 +            {


### PR DESCRIPTION
wine commit 949dbbd31f450178c90ea8267097a975b77c3219 (release version 3.21), broke the d3dx9_36-DrawText patchset.
The wined3daccess_from_d3dpool function is responsible to get the right acces flags from the selected pool and flags. These include the WINED3D_RESOURCE_ACCESS_MAP_R and the WINED3D_RESOURCE_ACCESS_MAP_W flags (the second in particular is required to allow a texture to be locked in LockRect). 
Before commit 949dbbd31f450178c90ea8267097a975b77c3219 however, in the init_texture function in d3d9 the two flags were added unconditionally, after this commit they aren't added anymore.

wined3daccess_from_d3dpool doesn't add these two flags in case of D3DPOOL_DEFAULT without the D3DUSAGE_DYNAMIC flag, while it does when the DYNAMIC flag is specified.
 
Adding D3DUSAGE_DYNAMIC to the CreateTexture function made the patchset work againg.

Relevant bug report : https://bugs.winehq.org/show_bug.cgi?id=46733