### PR TITLE
patchinstall: Test for .git presence, regardless of its type.

### DIFF
--- a/staging/patchinstall.sh.in
+++ b/staging/patchinstall.sh.in
@@ -267,7 +267,7 @@ fi
 # subdirectory of a git tree, which has the effect that no patches
 # are applied, but the exitcode is zero. To avoid broken builds we
 # will workaround this issue or abort.
-test ! -d ".git" && git rev-parse --git-dir >/dev/null 2>&1
+test ! -e ".git" && git rev-parse --git-dir >/dev/null 2>&1
 workaround_git_bug="$?"
 
 # Apply the patches using gitapply.sh, a small wrapper around 'patch'


### PR DESCRIPTION
It's possible that .git is a file, for example when using multiple
worktrees, and in this case git apply will still work fine.