### PR TITLE
Added kernel32-RaiseFailFastException patchset

### DIFF
--- a/patches/kernel32-RaiseFailFastException/0001-kernel32-Implement-RaiseFailFastException.patch
+++ b/patches/kernel32-RaiseFailFastException/0001-kernel32-Implement-RaiseFailFastException.patch
@@ -1,0 +1,100 @@
+From fd9437db7620a63cfaf9ffcca1f632ce163b477c Mon Sep 17 00:00:00 2001
+From: André Hentschel <nerv@dawncrow.de>
+Date: Mon, 27 Jan 2020 11:00:34 +0100
+Subject: [PATCH] kernel32: Implement RaiseFailFastException
+
+---
+ dlls/kernel32/kernel32.spec     |  2 +-
+ dlls/kernelbase/debug.c         | 36 +++++++++++++++++++++++++++++++++
+ dlls/kernelbase/kernelbase.spec |  2 +-
+ include/ntstatus.h              |  1 +
+ 4 files changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/kernel32/kernel32.spec b/dlls/kernel32/kernel32.spec
+index be48ef1..6d18f86 100644
+--- a/dlls/kernel32/kernel32.spec
++++ b/dlls/kernel32/kernel32.spec
+@@ -1184,7 +1184,7 @@
+ @ stdcall -import QueueUserAPC(ptr long long)
+ @ stdcall -import QueueUserWorkItem(ptr ptr long)
+ @ stdcall -import RaiseException(long long long ptr)
+-# @ stub RaiseFailFastException
++@ stdcall -import RaiseFailFastException(ptr ptr long)
+ @ stdcall ReadConsoleA(long ptr long ptr ptr)
+ @ stdcall ReadConsoleInputA(long ptr long ptr)
+ @ stub ReadConsoleInputExA
+diff --git a/dlls/kernelbase/debug.c b/dlls/kernelbase/debug.c
+index 53b95aa..7aaca40 100644
+--- a/dlls/kernelbase/debug.c
++++ b/dlls/kernelbase/debug.c
+@@ -746,6 +746,42 @@ static BOOL check_resource_write( void *addr )
+ }
+ 
+ 
++/*******************************************************************
++ *         RaiseFailFastException   (kernelbase.@)
++ */
++void WINAPI RaiseFailFastException(EXCEPTION_RECORD *record, CONTEXT *context, DWORD flags)
++{
++    EXCEPTION_RECORD rec;
++    CONTEXT ctx;
++
++    if (!context)
++    {
++        ctx.ContextFlags = CONTEXT_FULL;
++        NtGetContextThread(GetCurrentThread(), &ctx);
++        context = &ctx;
++    }
++
++    if (!record)
++    {
++        rec.ExceptionCode    = STATUS_FAIL_FAST_EXCEPTION;
++        rec.ExceptionFlags   = 0;
++        rec.ExceptionRecord  = NULL;
++        rec.ExceptionAddress = RaiseFailFastException;
++        rec.NumberParameters = 0;
++        record = &rec;
++    }
++
++    if (!NtCurrentTeb()->Peb->BeingDebugged)
++    {
++        EXCEPTION_POINTERS epointers;
++
++        epointers.ExceptionRecord = record;
++        epointers.ContextRecord = context;
++        start_debugger_atomic(&epointers);
++    }
++}
++
++
+ /*******************************************************************
+  *         UnhandledExceptionFilter   (kernelbase.@)
+  */
+diff --git a/dlls/kernelbase/kernelbase.spec b/dlls/kernelbase/kernelbase.spec
+index f36d4d5..9cf6a87 100644
+--- a/dlls/kernelbase/kernelbase.spec
++++ b/dlls/kernelbase/kernelbase.spec
+@@ -1232,7 +1232,7 @@
+ # @ stub QuirkIsEnabledForPackage4
+ # @ stub QuirkIsEnabledForProcess
+ @ stdcall RaiseException(long long long ptr)
+-# @ stub RaiseFailFastException
++@ stdcall RaiseFailFastException(ptr ptr long)
+ @ stdcall ReOpenFile(ptr long long long)
+ @ stdcall ReadConsoleA(long ptr long ptr ptr) kernel32.ReadConsoleA
+ @ stdcall ReadConsoleInputA(long ptr long ptr) kernel32.ReadConsoleInputA
+diff --git a/include/ntstatus.h b/include/ntstatus.h
+index 682db7a..65bb3b3 100644
+--- a/include/ntstatus.h
++++ b/include/ntstatus.h
+@@ -943,6 +943,7 @@
+ #define STATUS_INVALID_TASK_INDEX           ((NTSTATUS) 0xC0000501)
+ #define STATUS_THREAD_ALREADY_IN_TASK       ((NTSTATUS) 0xC0000502)
+ #define STATUS_CALLBACK_BYPASS              ((NTSTATUS) 0xC0000503)
++#define STATUS_FAIL_FAST_EXCEPTION          ((NTSTATUS) 0xC0000602)
+ #define STATUS_PORT_CLOSED                  ((NTSTATUS) 0xC0000700)
+ #define STATUS_MESSAGE_LOST                 ((NTSTATUS) 0xC0000701)
+ #define STATUS_INVALID_MESSAGE              ((NTSTATUS) 0xC0000702)
+-- 
+2.17.1
+

--- a/patches/kernel32-RaiseFailFastException/definition
+++ b/patches/kernel32-RaiseFailFastException/definition
@@ -1,0 +1,1 @@
+Fixes: [46155] Windows PowerShell Core 6.1 for ARM64 crashes on unimplemented function KERNEL32.dll.RaiseFailFastException


### PR DESCRIPTION
The patch comes from to https://bugs.winehq.org/show_bug.cgi?id=46155
Apparently the code should move from kernel32 to kernelbase