### PR TITLE
Add a GitHub action to test building for macOS

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -1,0 +1,128 @@
+name: MacOS
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  wine-staging:
+    runs-on:  macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          brew install --cask xquartz
+          brew install  bison \
+                        faudio \
+                        gphoto2 \
+                        gst-plugins-base \
+                        little-cms2 \
+                        mingw-w64 \
+                        molten-vk \
+                        mpg123
+
+      - name: Add bison & krb5 to $PATH
+        run: |
+          set -eu
+          echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix krb5)/bin" >> $GITHUB_PATH
+
+      - name: Get upstream-commit
+        run: |
+          mkdir $GITHUB_WORKSPACE/wine
+          cd wine
+          git init
+          git fetch https://github.com/wine-mirror/wine.git $($GITHUB_WORKSPACE/patches/patchinstall.sh --upstream-commit) --depth=1
+          git checkout $($GITHUB_WORKSPACE/patches/patchinstall.sh --upstream-commit)
+
+      - name: Run patchinstall.sh --all
+        run: |
+          $GITHUB_WORKSPACE/patches/patchinstall.sh DESTDIR=$GITHUB_WORKSPACE/wine --all
+
+      - name: Configure wine64
+        env:
+          LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
+          # Avoid weird linker errors with Xcode 10 and later
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
+        run: |
+          cd $GITHUB_WORKSPACE/wine
+          ./configure   --enable-win64 \
+                        --without-alsa \
+                        --without-capi \
+                        --without-dbus \
+                        --without-inotify \
+                        --without-oss \
+                        --without-pulse \
+                        --without-udev \
+                        --without-v4l2 \
+                        --x-include=/opt/X11/include \
+                        --x-lib=/opt/X11/lib
+
+      - name: Build wine64
+        run: |
+          cd $GITHUB_WORKSPACE/wine
+          make -j$(sysctl -n hw.ncpu 2>/dev/null)
+
+  wine-devel:
+    runs-on:  macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          brew install --cask xquartz
+          brew install  bison \
+                        faudio \
+                        gphoto2 \
+                        gst-plugins-base \
+                        little-cms2 \
+                        mingw-w64 \
+                        molten-vk \
+                        mpg123
+
+      - name: Add bison & krb5 to $PATH
+        run: |
+          set -eu
+          echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix krb5)/bin" >> $GITHUB_PATH
+
+      - name: Get upstream-commit
+        run: |
+          mkdir $GITHUB_WORKSPACE/wine
+          cd wine
+          git init
+          git fetch https://github.com/wine-mirror/wine.git $($GITHUB_WORKSPACE/patches/patchinstall.sh --upstream-commit) --depth=1
+          git checkout $($GITHUB_WORKSPACE/patches/patchinstall.sh --upstream-commit)
+
+      - name: Configure wine64
+        env:
+          LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
+          # Avoid weird linker errors with Xcode 10 and later
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
+        run: |
+          cd $GITHUB_WORKSPACE/wine
+
+          cd $GITHUB_WORKSPACE/wine
+          ./configure   --enable-win64 \
+                        --without-alsa \
+                        --without-capi \
+                        --without-dbus \
+                        --without-inotify \
+                        --without-oss \
+                        --without-pulse \
+                        --without-udev \
+                        --without-v4l2 \
+                        --x-include=/opt/X11/include \
+                        --x-lib=/opt/X11/lib
+
+      - name: Build wine64
+        run: |
+          cd $GITHUB_WORKSPACE/wine
+          make -j$(sysctl -n hw.ncpu 2>/dev/null)


### PR DESCRIPTION
The following GitHub action will trigger a build on push and pull-request, this can also be triggered manually.

The workflow will grab the same commit that staging is currently rebased against from the GitHub wine-mirror and build both wine-staging and wine-devel.
The reason wine-devel is also built is to ensure a breakage wasn’t caused by devel.

As per @zfigura Xcode default behavior was left alone, that’s what initially caught https://github.com/wine-staging/wine-staging/commit/f4cb879b3d6963b70e46976bae1be42b1143e9da

Only Linux specific components were disabled.