### PR TITLE
macOS.yml: Disable Xcode12 forced -Werror,-Wimplicit-function-declaration - !DON’T MERGE!

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -50,7 +50,7 @@ jobs:
           # Xcode12 by default enables '-Werror,-Wimplicit-function-declaration' (49917738)
           # this causes wine(64) builds to fail so needs to be disabled.
           # https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
-          CFLAGS: "-Wno-implicit-function-declaration"
+          CFLAGS: "-Wimplicit-function-declaration"
           LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
           # Avoid weird linker errors with Xcode 10 and later
           MACOSX_DEPLOYMENT_TARGET: "10.14"
@@ -110,7 +110,7 @@ jobs:
           # Xcode12 by default enables '-Werror,-Wimplicit-function-declaration' (49917738)
           # this causes wine(64) builds to fail so needs to be disabled.
           # https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
-          CFLAGS: "-Wno-implicit-function-declaration"
+          CFLAGS: "-Wimplicit-function-declaration"
           LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
           # Avoid weird linker errors with Xcode 10 and later
           MACOSX_DEPLOYMENT_TARGET: "10.14"

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -47,6 +47,10 @@ jobs:
 
       - name: Configure wine64
         env:
+          # Xcode12 by default enables '-Werror,-Wimplicit-function-declaration' (49917738)
+          # this causes wine(64) builds to fail so needs to be disabled.
+          # https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
+          CFLAGS: "-Wno-implicit-function-declaration"
           LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
           # Avoid weird linker errors with Xcode 10 and later
           MACOSX_DEPLOYMENT_TARGET: "10.14"
@@ -103,6 +107,10 @@ jobs:
 
       - name: Configure wine64
         env:
+          # Xcode12 by default enables '-Werror,-Wimplicit-function-declaration' (49917738)
+          # this causes wine(64) builds to fail so needs to be disabled.
+          # https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
+          CFLAGS: "-Wno-implicit-function-declaration"
           LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
           # Avoid weird linker errors with Xcode 10 and later
           MACOSX_DEPLOYMENT_TARGET: "10.14"

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -50,7 +50,7 @@ jobs:
           # Xcode12 by default enables '-Werror,-Wimplicit-function-declaration' (49917738)
           # this causes wine(64) builds to fail so needs to be disabled.
           # https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
-          CFLAGS: "-Wimplicit-function-declaration"
+          #CFLAGS: "-Wno-implicit-function-declaration"
           LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
           # Avoid weird linker errors with Xcode 10 and later
           MACOSX_DEPLOYMENT_TARGET: "10.14"
@@ -110,7 +110,7 @@ jobs:
           # Xcode12 by default enables '-Werror,-Wimplicit-function-declaration' (49917738)
           # this causes wine(64) builds to fail so needs to be disabled.
           # https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
-          CFLAGS: "-Wimplicit-function-declaration"
+          #CFLAGS: "-Wno-implicit-function-declaration"
           LDFLAGS: "-Wl,-rpath,/opt/X11/lib"
           # Avoid weird linker errors with Xcode 10 and later
           MACOSX_DEPLOYMENT_TARGET: "10.14"


### PR DESCRIPTION
This causes problems when headers are deemed "missing" when that's not the case for gcc and upstream clang.

As theres currently no Winehq testbot macOS support maybe allowing Xcode to die on these "errors" isn't ideal, disabling this option means Xcode12+ behavior now matches upstream clang.