### PR TITLE
macOS.yml: Added jxrlib

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,10 +2,7 @@ name: MacOS
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
-
   workflow_dispatch:
 
 jobs:
@@ -17,11 +14,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew update
           brew install --cask xquartz
           brew install  bison \
                         faudio \
                         gphoto2 \
                         gst-plugins-base \
+                        jxrlib \
                         little-cms2 \
                         mingw-w64 \
                         molten-vk \
@@ -77,11 +76,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew update
           brew install --cask xquartz
           brew install  bison \
                         faudio \
                         gphoto2 \
                         gst-plugins-base \
+                        jxrlib \
                         little-cms2 \
                         mingw-w64 \
                         molten-vk \


### PR DESCRIPTION
Since https://github.com/Homebrew/homebrew-core/commit/5f7694179cec2fe63fcc5cd6a5f66d2aee7f7170 the formula now builds dylibs on macOS.

Some additional tweaks, `brew update` is ran to ensure the latest bottles are used for installation to avoid waiting on GitHub updating the CI image.

Pull-requests from any branch will be built not just from the master branch.