### PR TITLE
macOS.yml: Use mingw-w64@9

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -19,7 +19,7 @@ jobs:
           brew install  bison \
                         gphoto2 \
                         gst-plugins-base \
-                        mingw-w64 \
+                        gcenx/wine/mingw-w64@9 \
                         molten-vk \
                         sdl2
 
@@ -28,6 +28,7 @@ jobs:
           set -eu
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
           echo "$(brew --prefix krb5)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix mingw-w64@9)/bin" >> $GITHUB_PATH
 
       - name: Get upstream-commit
         run: |
@@ -62,9 +63,10 @@ jobs:
 
       - name: Build wine64
         # mingw-w64 brew formula bumped binutils 2.38 causing a regression in parallel builds
+        # use gcenx/wine/mingw-w64@9 this uses binutils 2.37
         run: |
           cd $GITHUB_WORKSPACE/wine
-          make
+          make -j$(sysctl -n hw.ncpu 2>/dev/null)
 
   wine-devel:
     runs-on:  macos-latest
@@ -82,7 +84,7 @@ jobs:
                         gst-plugins-base \
                         jxrlib \
                         little-cms2 \
-                        mingw-w64 \
+                        gcenx/wine/mingw-w64@9 \
                         molten-vk \
                         mpg123
 
@@ -91,6 +93,7 @@ jobs:
           set -eu
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
           echo "$(brew --prefix krb5)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix mingw-w64@9)/bin" >> $GITHUB_PATH
 
       - name: Get upstream-commit
         run: |
@@ -123,6 +126,7 @@ jobs:
 
       - name: Build wine64
         # mingw-w64 brew formula bumped binutils 2.38 causing a regression in parallel builds
+        # use gcenx/wine/mingw-w64@9 this uses binutils 2.37
         run: |
           cd $GITHUB_WORKSPACE/wine
-          make
+          make -j$(sysctl -n hw.ncpu 2>/dev/null)


### PR DESCRIPTION
mingw-w64@9 is a keg_only formula that use binutils 2.37 this restores parallel compiles.

Seems dlltool isn’t the only thing that’s broken in binutils 2.38 so it seems better to revert back to 2.37 for now.