### PR TITLE
macOS.yml: Cleanup workflows

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -19,7 +19,7 @@ jobs:
           brew install  bison \
                         gphoto2 \
                         gst-plugins-base \
-                        gcenx/wine/mingw-w64@9 \
+                        mingw-w64 \
                         molten-vk \
                         sdl2
 
@@ -28,7 +28,6 @@ jobs:
           set -eu
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
           echo "$(brew --prefix krb5)/bin" >> $GITHUB_PATH
-          echo "$(brew --prefix mingw-w64@9)/bin" >> $GITHUB_PATH
 
       - name: Get upstream-commit
         run: |
@@ -62,8 +61,6 @@ jobs:
                         --x-lib=/opt/X11/lib
 
       - name: Build wine64
-        # mingw-w64 brew formula bumped binutils 2.38 causing a regression in parallel builds
-        # use gcenx/wine/mingw-w64@9 this uses binutils 2.37
         run: |
           cd $GITHUB_WORKSPACE/wine
           make -j$(sysctl -n hw.ncpu 2>/dev/null)
@@ -79,12 +76,9 @@ jobs:
           brew update
           brew install --cask xquartz
           brew install  bison \
-                        faudio \
                         gphoto2 \
                         gst-plugins-base \
-                        jxrlib \
-                        little-cms2 \
-                        gcenx/wine/mingw-w64@9 \
+                        mingw-w64 \
                         molten-vk \
                         mpg123
 
@@ -93,7 +87,6 @@ jobs:
           set -eu
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
           echo "$(brew --prefix krb5)/bin" >> $GITHUB_PATH
-          echo "$(brew --prefix mingw-w64@9)/bin" >> $GITHUB_PATH
 
       - name: Get upstream-commit
         run: |
@@ -125,8 +118,6 @@ jobs:
                         --x-lib=/opt/X11/lib
 
       - name: Build wine64
-        # mingw-w64 brew formula bumped binutils 2.38 causing a regression in parallel builds
-        # use gcenx/wine/mingw-w64@9 this uses binutils 2.37
         run: |
           cd $GITHUB_WORKSPACE/wine
           make -j$(sysctl -n hw.ncpu 2>/dev/null)


### PR DESCRIPTION
- Use brews mingw-w64 formula again
- Cleanup notes
- Remove unneeded formulas from wine-devel