### PR TITLE
Update 0008-winegstreamer-Allow-videoconvert-to-parallelize.patch

### DIFF
--- a/patches/mfplat-streaming-support/0008-winegstreamer-Allow-videoconvert-to-parallelize.patch
+++ b/patches/mfplat-streaming-support/0008-winegstreamer-Allow-videoconvert-to-parallelize.patch
@@ -19,7 +19,7 @@ index 2fa87ac611b..2b3cc2633e3 100644
              goto out;
  
 +        /* Let GStreamer choose a default number of threads. */
-+        gst_util_set_object_arg(G_OBJECT(vconv), "n-threads", "0");
++        gst_util_set_object_arg(G_OBJECT(element), "n-threads", "0");
 +
          /* GStreamer outputs RGB video top-down, but DirectShow expects bottom-up. */
          if (!(element = create_element("videoflip", "good"))


### PR DESCRIPTION
vconv doesn't exist any more, I think this needs to be element